### PR TITLE
[0.5.2 release] Delete and replace `helm-chart` directory with the one from `kuberay` at `0.5.2`

### DIFF
--- a/helm-chart/kuberay-apiserver/Chart.yaml
+++ b/helm-chart/kuberay-apiserver/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 name: "kuberay-apiserver"
 image:
   repository: kuberay/apiserver
-  tag: v0.5.0
+  tag: v0.5.2
   pullPolicy: IfNotPresent
 
 ## Install Default RBAC roles and bindings

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: kuberay-operator
-version: 0.5.1
+version: 0.5.2
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png
 type: application

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -340,6 +340,42 @@ spec:
                     - Aggressive
                     - Conservative
                     type: string
+                  volumeMounts:
+                    description: Optional list of volumeMounts.  This is needed for
+                      enabling TLS for the autoscaler container.
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            a
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted.
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which
+                            the container's volume should be mounted.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
                 type: object
               enableInTreeAutoscaling:
                 description: EnableInTreeAutoscaling indicates whether operator should
@@ -353,6 +389,310 @@ spec:
                     description: EnableIngress indicates whether operator should create
                       ingress object for head service or not.
                     type: boolean
+                  headService:
+                    description: HeadService is the Kubernetes service of the head
+                      pod.
+                    properties:
+                      apiVersion:
+                        description: APIVersion defines the versioned schema of this
+                          representation of an object.
+                        type: string
+                      kind:
+                        description: Kind is a string value representing the REST
+                          resource this object represents.
+                        type: string
+                      metadata:
+                        description: 'Standard object''s metadata. More info: https://git.k8s.'
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        description: Spec defines the behavior of a service. https://git.k8s.
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            description: allocateLoadBalancerNodePorts defines if
+                              NodePorts will be automatically allocated for services
+                              with
+                            type: boolean
+                          clusterIP:
+                            description: clusterIP is the IP address of the service
+                              and is usually assigned randomly.
+                            type: string
+                          clusterIPs:
+                            description: ClusterIPs is a list of IP addresses assigned
+                              to this service, and are usually assigned randomly.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for
+                              which nodes in the cluster will also accept traffic
+                              for th
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that
+                              discovery mechanisms will return as an alias for this
+                              se
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service
+                              desires to route external traffic to node-local or clu
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck
+                              nodePort for the service.
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            description: InternalTrafficPolicy specifies if the cluster
+                              internal traffic should be routed to all endpoints or
+                            type: string
+                          ipFamilies:
+                            description: IPFamilies is a list of IP families (e.g.
+                              IPv4, IPv6) assigned to this service.
+                            items:
+                              description: IPFamily represents the IP Family (IPv4
+                                or IPv6).
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            description: IPFamilyPolicy represents the dual-stack-ness
+                              requested or required by this Service.
+                            type: string
+                          loadBalancerClass:
+                            description: loadBalancerClass is the class of the load
+                              balancer implementation this Service belongs to.
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer
+                              LoadBalancer will get created with the IP specified
+                              in th'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: If specified and supported by the platform,
+                              this will restrict traffic through the cloud-provider
+                              lo
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            description: 'The list of ports that are exposed by this
+                              service. More info: https://kubernetes.'
+                            items:
+                              description: ServicePort contains information on service's
+                                port.
+                              properties:
+                                appProtocol:
+                                  description: The application protocol for this port.
+                                    This field follows standard Kubernetes label syntax.
+                                  type: string
+                                name:
+                                  description: The name of this port within the service.
+                                    This must be a DNS_LABEL.
+                                  type: string
+                                nodePort:
+                                  description: The port on each node on which this
+                                    service is exposed when type is NodePort or LoadBalancer.
+                                  format: int32
+                                  type: integer
+                                port:
+                                  description: The port that will be exposed by this
+                                    service.
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: The IP protocol for this port. Supports
+                                    "TCP", "UDP", and "SCTP". Default is TCP.
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the pods targeted by the service.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any
+                              agent which deals with endpoints for this Service should
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: Route service traffic to pods with label
+                              keys and values matching this selector.
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            description: Supports "ClientIP" and "None". Used to maintain
+                              session affinity.
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations
+                              of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations
+                                  of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds
+                                      of ClientIP type session sticky time.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            description: type determines how the Service is exposed.
+                              Defaults to ClusterIP.
+                            type: string
+                        type: object
+                      status:
+                        description: Most recently observed status of the service.
+                          Populated by the system. Read-only.
+                        properties:
+                          conditions:
+                            description: Current service state
+                            items:
+                              description: Condition contains details for one aspect
+                                of the current state of this API Resource.
+                              properties:
+                                lastTransitionTime:
+                                  description: lastTransitionTime is the last time
+                                    the condition transitioned from one status to
+                                    another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: message is a human readable message
+                                    indicating details about the transition.
+                                  maxLength: 32768
+                                  type: string
+                                observedGeneration:
+                                  description: observedGeneration represents the .metadata.generation
+                                    that the condition was set based upon.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                                reason:
+                                  description: reason contains a programmatic identifier
+                                    indicating the reason for the condition's last
+                                    transition.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                  type: string
+                                status:
+                                  description: status of the condition, one of True,
+                                    False, Unknown.
+                                  enum:
+                                  - "True"
+                                  - "False"
+                                  - Unknown
+                                  type: string
+                                type:
+                                  description: type of condition in CamelCase or in
+                                    foo.example.com/CamelCase. --- Many .condition.
+                                  maxLength: 316
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                  type: string
+                              required:
+                              - lastTransitionTime
+                              - message
+                              - reason
+                              - status
+                              - type
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - type
+                            x-kubernetes-list-type: map
+                          loadBalancer:
+                            description: LoadBalancer contains the current status
+                              of the load-balancer, if one is present.
+                            properties:
+                              ingress:
+                                description: Ingress is a list containing ingress
+                                  points for the load-balancer.
+                                items:
+                                  description: 'LoadBalancerIngress represents the
+                                    status of a load-balancer ingress point: traffic
+                                    intended for the'
+                                  properties:
+                                    hostname:
+                                      description: Hostname is set for load-balancer
+                                        ingress points that are DNS based (typically
+                                        AWS load-balancers)
+                                      type: string
+                                    ip:
+                                      description: IP is set for load-balancer ingress
+                                        points that are IP based (typically GCE or
+                                        OpenStack load-balanc
+                                      type: string
+                                    ports:
+                                      description: Ports is a list of records of service
+                                        ports If used, every port defined in the service
+                                        should have a
+                                      items:
+                                        properties:
+                                          error:
+                                            description: Error is to record the problem
+                                              with the service port The format of
+                                              the error shall comply with the f
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                          port:
+                                            description: Port is the port number of
+                                              the service port of which status is
+                                              recorded here
+                                            format: int32
+                                            type: integer
+                                          protocol:
+                                            default: TCP
+                                            description: Protocol is the protocol
+                                              of the service port of which status
+                                              is recorded here The supported values
+                                              a
+                                            type: string
+                                        required:
+                                        - port
+                                        - protocol
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
                   rayStartParams:
                     additionalProperties:
                       type: string

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -348,6 +348,42 @@ spec:
                         - Aggressive
                         - Conservative
                         type: string
+                      volumeMounts:
+                        description: Optional list of volumeMounts.  This is needed
+                          for enabling TLS for the autoscaler container.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way a
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted.
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
                     type: object
                   enableInTreeAutoscaling:
                     description: EnableInTreeAutoscaling indicates whether operator
@@ -361,6 +397,323 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      headService:
+                        description: HeadService is the Kubernetes service of the
+                          head pod.
+                        properties:
+                          apiVersion:
+                            description: APIVersion defines the versioned schema of
+                              this representation of an object.
+                            type: string
+                          kind:
+                            description: Kind is a string value representing the REST
+                              resource this object represents.
+                            type: string
+                          metadata:
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                          spec:
+                            description: Spec defines the behavior of a service. https://git.k8s.
+                            properties:
+                              allocateLoadBalancerNodePorts:
+                                description: allocateLoadBalancerNodePorts defines
+                                  if NodePorts will be automatically allocated for
+                                  services with
+                                type: boolean
+                              clusterIP:
+                                description: clusterIP is the IP address of the service
+                                  and is usually assigned randomly.
+                                type: string
+                              clusterIPs:
+                                description: ClusterIPs is a list of IP addresses
+                                  assigned to this service, and are usually assigned
+                                  randomly.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              externalIPs:
+                                description: externalIPs is a list of IP addresses
+                                  for which nodes in the cluster will also accept
+                                  traffic for th
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                description: externalName is the external reference
+                                  that discovery mechanisms will return as an alias
+                                  for this se
+                                type: string
+                              externalTrafficPolicy:
+                                description: externalTrafficPolicy denotes if this
+                                  Service desires to route external traffic to node-local
+                                  or clu
+                                type: string
+                              healthCheckNodePort:
+                                description: healthCheckNodePort specifies the healthcheck
+                                  nodePort for the service.
+                                format: int32
+                                type: integer
+                              internalTrafficPolicy:
+                                description: InternalTrafficPolicy specifies if the
+                                  cluster internal traffic should be routed to all
+                                  endpoints or
+                                type: string
+                              ipFamilies:
+                                description: IPFamilies is a list of IP families (e.g.
+                                  IPv4, IPv6) assigned to this service.
+                                items:
+                                  description: IPFamily represents the IP Family (IPv4
+                                    or IPv6).
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ipFamilyPolicy:
+                                description: IPFamilyPolicy represents the dual-stack-ness
+                                  requested or required by this Service.
+                                type: string
+                              loadBalancerClass:
+                                description: loadBalancerClass is the class of the
+                                  load balancer implementation this Service belongs
+                                  to.
+                                type: string
+                              loadBalancerIP:
+                                description: 'Only applies to Service Type: LoadBalancer
+                                  LoadBalancer will get created with the IP specified
+                                  in th'
+                                type: string
+                              loadBalancerSourceRanges:
+                                description: If specified and supported by the platform,
+                                  this will restrict traffic through the cloud-provider
+                                  lo
+                                items:
+                                  type: string
+                                type: array
+                              ports:
+                                description: 'The list of ports that are exposed by
+                                  this service. More info: https://kubernetes.'
+                                items:
+                                  description: ServicePort contains information on
+                                    service's port.
+                                  properties:
+                                    appProtocol:
+                                      description: The application protocol for this
+                                        port. This field follows standard Kubernetes
+                                        label syntax.
+                                      type: string
+                                    name:
+                                      description: The name of this port within the
+                                        service. This must be a DNS_LABEL.
+                                      type: string
+                                    nodePort:
+                                      description: The port on each node on which
+                                        this service is exposed when type is NodePort
+                                        or LoadBalancer.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      description: The port that will be exposed by
+                                        this service.
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      default: TCP
+                                      description: The IP protocol for this port.
+                                        Supports "TCP", "UDP", and "SCTP". Default
+                                        is TCP.
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the pods targeted by the service.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                description: publishNotReadyAddresses indicates that
+                                  any agent which deals with endpoints for this Service
+                                  should
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                description: Route service traffic to pods with label
+                                  keys and values matching this selector.
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sessionAffinity:
+                                description: Supports "ClientIP" and "None". Used
+                                  to maintain session affinity.
+                                type: string
+                              sessionAffinityConfig:
+                                description: sessionAffinityConfig contains the configurations
+                                  of session affinity.
+                                properties:
+                                  clientIP:
+                                    description: clientIP contains the configurations
+                                      of Client IP based session affinity.
+                                    properties:
+                                      timeoutSeconds:
+                                        description: timeoutSeconds specifies the
+                                          seconds of ClientIP type session sticky
+                                          time.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              type:
+                                description: type determines how the Service is exposed.
+                                  Defaults to ClusterIP.
+                                type: string
+                            type: object
+                          status:
+                            description: Most recently observed status of the service.
+                              Populated by the system. Read-only.
+                            properties:
+                              conditions:
+                                description: Current service state
+                                items:
+                                  description: Condition contains details for one
+                                    aspect of the current state of this API Resource.
+                                  properties:
+                                    lastTransitionTime:
+                                      description: lastTransitionTime is the last
+                                        time the condition transitioned from one status
+                                        to another.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: message is a human readable message
+                                        indicating details about the transition.
+                                      maxLength: 32768
+                                      type: string
+                                    observedGeneration:
+                                      description: observedGeneration represents the
+                                        .metadata.generation that the condition was
+                                        set based upon.
+                                      format: int64
+                                      minimum: 0
+                                      type: integer
+                                    reason:
+                                      description: reason contains a programmatic
+                                        identifier indicating the reason for the condition's
+                                        last transition.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                      type: string
+                                    status:
+                                      description: status of the condition, one of
+                                        True, False, Unknown.
+                                      enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                      type: string
+                                    type:
+                                      description: type of condition in CamelCase
+                                        or in foo.example.com/CamelCase. --- Many
+                                        .condition.
+                                      maxLength: 316
+                                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                      type: string
+                                  required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - type
+                                x-kubernetes-list-type: map
+                              loadBalancer:
+                                description: LoadBalancer contains the current status
+                                  of the load-balancer, if one is present.
+                                properties:
+                                  ingress:
+                                    description: Ingress is a list containing ingress
+                                      points for the load-balancer.
+                                    items:
+                                      description: 'LoadBalancerIngress represents
+                                        the status of a load-balancer ingress point:
+                                        traffic intended for the'
+                                      properties:
+                                        hostname:
+                                          description: Hostname is set for load-balancer
+                                            ingress points that are DNS based (typically
+                                            AWS load-balancers)
+                                          type: string
+                                        ip:
+                                          description: IP is set for load-balancer
+                                            ingress points that are IP based (typically
+                                            GCE or OpenStack load-balanc
+                                          type: string
+                                        ports:
+                                          description: Ports is a list of records
+                                            of service ports If used, every port defined
+                                            in the service should have a
+                                          items:
+                                            properties:
+                                              error:
+                                                description: Error is to record the
+                                                  problem with the service port The
+                                                  format of the error shall comply
+                                                  with the f
+                                                maxLength: 316
+                                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                                type: string
+                                              port:
+                                                description: Port is the port number
+                                                  of the service port of which status
+                                                  is recorded here
+                                                format: int32
+                                                type: integer
+                                              protocol:
+                                                default: TCP
+                                                description: Protocol is the protocol
+                                                  of the service port of which status
+                                                  is recorded here The supported values
+                                                  a
+                                                type: string
+                                            required:
+                                            - port
+                                            - protocol
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string
@@ -11742,6 +12095,10 @@ spec:
               shutdownAfterJobFinishes:
                 description: ShutdownAfterJobFinishes will determine whether to delete
                   the ray cluster once rayJob succeed or fai
+                type: boolean
+              suspend:
+                description: suspend specifies whether the RayJob controller should
+                  create a RayCluster instance If a job is appl
                 type: boolean
               ttlSecondsAfterFinished:
                 description: TTLSecondsAfterFinished is the TTL to clean up RayCluster.

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -334,6 +334,42 @@ spec:
                         - Aggressive
                         - Conservative
                         type: string
+                      volumeMounts:
+                        description: Optional list of volumeMounts.  This is needed
+                          for enabling TLS for the autoscaler container.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way a
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted.
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
                     type: object
                   enableInTreeAutoscaling:
                     description: EnableInTreeAutoscaling indicates whether operator
@@ -347,6 +383,323 @@ spec:
                         description: EnableIngress indicates whether operator should
                           create ingress object for head service or not.
                         type: boolean
+                      headService:
+                        description: HeadService is the Kubernetes service of the
+                          head pod.
+                        properties:
+                          apiVersion:
+                            description: APIVersion defines the versioned schema of
+                              this representation of an object.
+                            type: string
+                          kind:
+                            description: Kind is a string value representing the REST
+                              resource this object represents.
+                            type: string
+                          metadata:
+                            description: 'Standard object''s metadata. More info:
+                              https://git.k8s.'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                            type: object
+                          spec:
+                            description: Spec defines the behavior of a service. https://git.k8s.
+                            properties:
+                              allocateLoadBalancerNodePorts:
+                                description: allocateLoadBalancerNodePorts defines
+                                  if NodePorts will be automatically allocated for
+                                  services with
+                                type: boolean
+                              clusterIP:
+                                description: clusterIP is the IP address of the service
+                                  and is usually assigned randomly.
+                                type: string
+                              clusterIPs:
+                                description: ClusterIPs is a list of IP addresses
+                                  assigned to this service, and are usually assigned
+                                  randomly.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              externalIPs:
+                                description: externalIPs is a list of IP addresses
+                                  for which nodes in the cluster will also accept
+                                  traffic for th
+                                items:
+                                  type: string
+                                type: array
+                              externalName:
+                                description: externalName is the external reference
+                                  that discovery mechanisms will return as an alias
+                                  for this se
+                                type: string
+                              externalTrafficPolicy:
+                                description: externalTrafficPolicy denotes if this
+                                  Service desires to route external traffic to node-local
+                                  or clu
+                                type: string
+                              healthCheckNodePort:
+                                description: healthCheckNodePort specifies the healthcheck
+                                  nodePort for the service.
+                                format: int32
+                                type: integer
+                              internalTrafficPolicy:
+                                description: InternalTrafficPolicy specifies if the
+                                  cluster internal traffic should be routed to all
+                                  endpoints or
+                                type: string
+                              ipFamilies:
+                                description: IPFamilies is a list of IP families (e.g.
+                                  IPv4, IPv6) assigned to this service.
+                                items:
+                                  description: IPFamily represents the IP Family (IPv4
+                                    or IPv6).
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              ipFamilyPolicy:
+                                description: IPFamilyPolicy represents the dual-stack-ness
+                                  requested or required by this Service.
+                                type: string
+                              loadBalancerClass:
+                                description: loadBalancerClass is the class of the
+                                  load balancer implementation this Service belongs
+                                  to.
+                                type: string
+                              loadBalancerIP:
+                                description: 'Only applies to Service Type: LoadBalancer
+                                  LoadBalancer will get created with the IP specified
+                                  in th'
+                                type: string
+                              loadBalancerSourceRanges:
+                                description: If specified and supported by the platform,
+                                  this will restrict traffic through the cloud-provider
+                                  lo
+                                items:
+                                  type: string
+                                type: array
+                              ports:
+                                description: 'The list of ports that are exposed by
+                                  this service. More info: https://kubernetes.'
+                                items:
+                                  description: ServicePort contains information on
+                                    service's port.
+                                  properties:
+                                    appProtocol:
+                                      description: The application protocol for this
+                                        port. This field follows standard Kubernetes
+                                        label syntax.
+                                      type: string
+                                    name:
+                                      description: The name of this port within the
+                                        service. This must be a DNS_LABEL.
+                                      type: string
+                                    nodePort:
+                                      description: The port on each node on which
+                                        this service is exposed when type is NodePort
+                                        or LoadBalancer.
+                                      format: int32
+                                      type: integer
+                                    port:
+                                      description: The port that will be exposed by
+                                        this service.
+                                      format: int32
+                                      type: integer
+                                    protocol:
+                                      default: TCP
+                                      description: The IP protocol for this port.
+                                        Supports "TCP", "UDP", and "SCTP". Default
+                                        is TCP.
+                                      type: string
+                                    targetPort:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the pods targeted by the service.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                                x-kubernetes-list-type: map
+                              publishNotReadyAddresses:
+                                description: publishNotReadyAddresses indicates that
+                                  any agent which deals with endpoints for this Service
+                                  should
+                                type: boolean
+                              selector:
+                                additionalProperties:
+                                  type: string
+                                description: Route service traffic to pods with label
+                                  keys and values matching this selector.
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sessionAffinity:
+                                description: Supports "ClientIP" and "None". Used
+                                  to maintain session affinity.
+                                type: string
+                              sessionAffinityConfig:
+                                description: sessionAffinityConfig contains the configurations
+                                  of session affinity.
+                                properties:
+                                  clientIP:
+                                    description: clientIP contains the configurations
+                                      of Client IP based session affinity.
+                                    properties:
+                                      timeoutSeconds:
+                                        description: timeoutSeconds specifies the
+                                          seconds of ClientIP type session sticky
+                                          time.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              type:
+                                description: type determines how the Service is exposed.
+                                  Defaults to ClusterIP.
+                                type: string
+                            type: object
+                          status:
+                            description: Most recently observed status of the service.
+                              Populated by the system. Read-only.
+                            properties:
+                              conditions:
+                                description: Current service state
+                                items:
+                                  description: Condition contains details for one
+                                    aspect of the current state of this API Resource.
+                                  properties:
+                                    lastTransitionTime:
+                                      description: lastTransitionTime is the last
+                                        time the condition transitioned from one status
+                                        to another.
+                                      format: date-time
+                                      type: string
+                                    message:
+                                      description: message is a human readable message
+                                        indicating details about the transition.
+                                      maxLength: 32768
+                                      type: string
+                                    observedGeneration:
+                                      description: observedGeneration represents the
+                                        .metadata.generation that the condition was
+                                        set based upon.
+                                      format: int64
+                                      minimum: 0
+                                      type: integer
+                                    reason:
+                                      description: reason contains a programmatic
+                                        identifier indicating the reason for the condition's
+                                        last transition.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                      type: string
+                                    status:
+                                      description: status of the condition, one of
+                                        True, False, Unknown.
+                                      enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                      type: string
+                                    type:
+                                      description: type of condition in CamelCase
+                                        or in foo.example.com/CamelCase. --- Many
+                                        .condition.
+                                      maxLength: 316
+                                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                      type: string
+                                  required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - type
+                                x-kubernetes-list-type: map
+                              loadBalancer:
+                                description: LoadBalancer contains the current status
+                                  of the load-balancer, if one is present.
+                                properties:
+                                  ingress:
+                                    description: Ingress is a list containing ingress
+                                      points for the load-balancer.
+                                    items:
+                                      description: 'LoadBalancerIngress represents
+                                        the status of a load-balancer ingress point:
+                                        traffic intended for the'
+                                      properties:
+                                        hostname:
+                                          description: Hostname is set for load-balancer
+                                            ingress points that are DNS based (typically
+                                            AWS load-balancers)
+                                          type: string
+                                        ip:
+                                          description: IP is set for load-balancer
+                                            ingress points that are IP based (typically
+                                            GCE or OpenStack load-balanc
+                                          type: string
+                                        ports:
+                                          description: Ports is a list of records
+                                            of service ports If used, every port defined
+                                            in the service should have a
+                                          items:
+                                            properties:
+                                              error:
+                                                description: Error is to record the
+                                                  problem with the service port The
+                                                  format of the error shall comply
+                                                  with the f
+                                                maxLength: 316
+                                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                                type: string
+                                              port:
+                                                description: Port is the port number
+                                                  of the service port of which status
+                                                  is recorded here
+                                                format: int32
+                                                type: integer
+                                              protocol:
+                                                default: TCP
+                                                description: Protocol is the protocol
+                                                  of the service port of which status
+                                                  is recorded here The supported values
+                                                  a
+                                                type: string
+                                            required:
+                                            - port
+                                            - protocol
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                        type: object
                       rayStartParams:
                         additionalProperties:
                           type: string
@@ -11784,10 +12137,306 @@ spec:
                     type: array
                   importPath:
                     type: string
+                  port:
+                    type: integer
                   runtimeEnv:
                     type: string
                 required:
                 - importPath
+                type: object
+              serveService:
+                description: ServeService is the Kubernetes service for head node
+                  and worker nodes who have healthy http proxy to
+                properties:
+                  apiVersion:
+                    description: APIVersion defines the versioned schema of this representation
+                      of an object.
+                    type: string
+                  kind:
+                    description: Kind is a string value representing the REST resource
+                      this object represents.
+                    type: string
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                  spec:
+                    description: Spec defines the behavior of a service. https://git.k8s.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with
+                        type: boolean
+                      clusterIP:
+                        description: clusterIP is the IP address of the service and
+                          is usually assigned randomly.
+                        type: string
+                      clusterIPs:
+                        description: ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for th
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this se
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or clu
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or
+                        type: string
+                      ipFamilies:
+                        description: IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service.
+                        items:
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service.
+                        type: string
+                      loadBalancerClass:
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in th'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: If specified and supported by the platform, this
+                          will restrict traffic through the cloud-provider lo
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL.
+                              type: string
+                            nodePort:
+                              description: The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on
+                                the pods targeted by the service.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Route service traffic to pods with label keys
+                          and values matching this selector.
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        description: Supports "ClientIP" and "None". Used to maintain
+                          session affinity.
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: type determines how the Service is exposed. Defaults
+                          to ClusterIP.
+                        type: string
+                    type: object
+                  status:
+                    description: Most recently observed status of the service. Populated
+                      by the system. Read-only.
+                    properties:
+                      conditions:
+                        description: Current service state
+                        items:
+                          description: Condition contains details for one aspect of
+                            the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the last time the
+                                condition transitioned from one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: message is a human readable message indicating
+                                details about the transition.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: observedGeneration represents the .metadata.generation
+                                that the condition was set based upon.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: reason contains a programmatic identifier
+                                indicating the reason for the condition's last transition.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                              - "True"
+                              - "False"
+                              - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                --- Many .condition.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                          - lastTransitionTime
+                          - message
+                          - reason
+                          - status
+                          - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - type
+                        x-kubernetes-list-type: map
+                      loadBalancer:
+                        description: LoadBalancer contains the current status of the
+                          load-balancer, if one is present.
+                        properties:
+                          ingress:
+                            description: Ingress is a list containing ingress points
+                              for the load-balancer.
+                            items:
+                              description: 'LoadBalancerIngress represents the status
+                                of a load-balancer ingress point: traffic intended
+                                for the'
+                              properties:
+                                hostname:
+                                  description: Hostname is set for load-balancer ingress
+                                    points that are DNS based (typically AWS load-balancers)
+                                  type: string
+                                ip:
+                                  description: IP is set for load-balancer ingress
+                                    points that are IP based (typically GCE or OpenStack
+                                    load-balanc
+                                  type: string
+                                ports:
+                                  description: Ports is a list of records of service
+                                    ports If used, every port defined in the service
+                                    should have a
+                                  items:
+                                    properties:
+                                      error:
+                                        description: Error is to record the problem
+                                          with the service port The format of the
+                                          error shall comply with the f
+                                        maxLength: 316
+                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                        type: string
+                                      port:
+                                        description: Port is the port number of the
+                                          service port of which status is recorded
+                                          here
+                                        format: int32
+                                        type: integer
+                                      protocol:
+                                        default: TCP
+                                        description: Protocol is the protocol of the
+                                          service port of which status is recorded
+                                          here The supported values a
+                                        type: string
+                                    required:
+                                    - port
+                                    - protocol
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            type: array
+                        type: object
+                    type: object
                 type: object
               serviceUnhealthySecondThreshold:
                 format: int32

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -42,10 +42,10 @@ spec:
             {{- $argList = append $argList "--enable-batch-scheduler" -}}
             {{- end -}}
             {{- $watchNamespace := "" -}}
-            {{- if .Values.singleNamespaceInstall -}}
+            {{- if and .Values.singleNamespaceInstall (not .Values.watchNamespace) -}}
             {{- $watchNamespace = .Release.Namespace -}}
             {{- else if .Values.watchNamespace -}}
-            {{- $watchNamespace = .Values.watchNamespace -}}
+            {{- $watchNamespace = join "," .Values.watchNamespace -}}
             {{- end -}}
             {{- if $watchNamespace -}}
             {{- $argList = append $argList "--watch-namespace" -}}

--- a/helm-chart/kuberay-operator/templates/leader_election_role.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role.yaml
@@ -2,8 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: {{ include "kuberay-operator.fullname" . }}-leader-election
 rules:
 - apiGroups:
@@ -32,4 +31,13 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
+++ b/helm-chart/kuberay-operator/templates/leader_election_role_binding.yaml
@@ -2,8 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: {{ include "kuberay-operator.fullname" . }}-leader-election
 subjects:
 - kind: ServiceAccount

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_role.yaml
@@ -1,11 +1,15 @@
-{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
-
-kind: ClusterRole
+# Install Role for namespaces listed in watchNamespace.
+# This should be consistent with `role.yaml`, except for the `kind` field.
+{{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
+{{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
+{{- range $namespace := $watchNamespaces }}
+---
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
-  name: {{ include "kuberay-operator.fullname" . }}
+  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
+  name: {{ include "kuberay-operator.fullname" $ }}
+  namespace: {{ $namespace }}
 rules:
 - apiGroups:
   - coordination.k8s.io
@@ -213,7 +217,7 @@ rules:
   - list
   - update
   - watch
-{{- if .Values.batchScheduler.enabled }}
+{{- if $.Values.batchScheduler.enabled }}
 - apiGroups:
   - scheduling.volcano.sh
   resources:
@@ -231,5 +235,6 @@ rules:
   - customresourcedefinitions
   verbs:
   - get
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/multiple_namespaces_rolebinding.yaml
@@ -1,0 +1,22 @@
+# Install RoleBinding for namespaces listed in watchNamespace.
+# This should be consistent with `rolebinding.yaml`, except for the `kind` field.
+{{- if and .Values.rbacEnable .Values.singleNamespaceInstall }}
+{{- $watchNamespaces := default (list .Release.Namespace) .Values.watchNamespace }}
+{{- range $namespace := $watchNamespaces }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels: {{ include "kuberay-operator.labels" $ | nindent 4 }}
+  name: {{ include "kuberay-operator.fullname" $ }}
+  namespace: {{ $namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.serviceAccount.name  }}
+  namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "kuberay-operator.fullname" $ }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_editor_role.yaml
@@ -1,15 +1,10 @@
 # permissions for end users to edit rayjobs.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: rayjob-editor-role
 rules:
 - apiGroups:

--- a/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayjob_viewer_role.yaml
@@ -1,15 +1,10 @@
 # permissions for end users to view rayjobs.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  labels:
-{{ include "kuberay-operator.labels" . | indent 4 }}
+  labels: {{ include "kuberay-operator.labels" . | nindent 4 }}
   name: rayjob-viewer-role
 rules:
 - apiGroups:

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_editor_role.yaml
@@ -1,12 +1,7 @@
 # permissions for end users to edit rayservices.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 apiVersion: rbac.authorization.k8s.io/v1
-
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: rayservice-editor-role
 rules:

--- a/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_rayservice_viewer_role.yaml
@@ -1,12 +1,7 @@
 # permissions for end users to view rayservices.
-{{- if .Values.rbacEnable }}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
 apiVersion: rbac.authorization.k8s.io/v1
-
-{{- if .Values.singleNamespaceInstall }}
-kind: Role
-{{- else }}
 kind: ClusterRole
-{{- end }}
 metadata:
   name: rayservice-viewer-role
 rules:

--- a/helm-chart/kuberay-operator/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-operator/templates/rolebinding.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.rbacEnable }}
-{{- if .Values.singleNamespaceInstall }}
-kind: RoleBinding
-{{- else }}
 kind: ClusterRoleBinding
-{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
@@ -14,11 +10,7 @@ subjects:
   name: {{ .Values.serviceAccount.name  }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-{{- if .Values.singleNamespaceInstall }}
-  kind: Role
-{{- else }}
   kind: ClusterRole
-{{- end }}
   name: {{ include "kuberay-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kuberay/operator
-  tag: v0.5.0
+  tag: v0.5.2
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay-operator"
@@ -55,18 +55,30 @@ batchScheduler:
 securityContext: {}
 
 # When singleNamespaceInstall is true:
-# - the chart can be installed by users with permissions to a single namespace only
-#   (this excludes the CRDs which can only be installed at cluster-scope)
-# - the KubeRay operator will only listen to the resource
-#   events from the operator's namespace by default
+# - Install namespaced RBAC resources instead of cluster-scoped ones so that the chart can be installed by users
+#   with permissions restricted to a single namespace. (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
+# - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
+#   to resource events within its own namespace.
 singleNamespaceInstall: false
 
-# kuberay operator will only watch the resource events from the "watchNamespace" namespace.
-# this option has no effect if singleNamespaceInstall is true, because we assume there are no
-# permissions outside of the current namespace
-# watchNamespace: ray-user-namespace
+# The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
+# watchNamespace:
+#   - n1
+#   - n2
 
 # Environment variables
-env: []
-# - name: EXAMPLE_ENV
-#   value: "1"
+env:
+# If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
+# If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
+# Warning: we highly recommend setting to true and let kuberay handle for you.
+# - name: ENABLE_INIT_CONTAINER_INJECTION
+#   value: "true"
+# If not set or set to "", kuberay will pick up the default k8s cluster domain `cluster.local`
+# Otherwise, kuberay will use your custom domain
+# - name: CLUSTER_DOMAIN
+#   value: ""
+# Unconditionally requeue after the number of seconds specified in the
+# environment variable RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV. If the
+# environment variable is not set, requeue after the default value (300).
+# - name: RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV
+#   value: 300

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ray-cluster
-version: 0.5.1
+version: 0.5.2
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -18,16 +18,23 @@ spec:
   autoscalerOptions: {{- toYaml .Values.head.autoscalerOptions | nindent 4 }}
   {{- end }}
   headGroupSpec:
+    {{- if .Values.head.headService }}
+    headService: {{- toYaml .Values.head.headService | nindent 6 }}
+    {{- end }}
     serviceType: {{ .Values.service.type }}
     rayStartParams:
-    {{- range $key, $val := .Values.head.rayStartParams }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- /*
-    initArgs is a deprecated alias for rayStartParams.
-    */}}
-    {{- range $key, $val := .Values.head.initArgs }}
-      {{ $key }}: {{ $val | quote }}
+    {{- if and (not .Values.head.rayStartParams) (not .Values.head.initArgs) }}
+      {}
+    {{- else }}
+      {{- range $key, $val := .Values.head.rayStartParams }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /*
+      initArgs is a deprecated alias for rayStartParams.
+      */}}
+      {{- range $key, $val := .Values.head.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
     {{- end }}
     template:
       spec:
@@ -81,14 +88,18 @@ spec:
   {{- range $groupName, $values := .Values.additionalWorkerGroups }}
   {{- if ne $values.disabled true }}
   - rayStartParams:
-    {{- range $key, $val := $values.rayStartParams }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- /*
-    initArgs is a deprecated alias for rayStartParams.
-    */}}
-    {{- range $key, $val := $values.initArgs }}
-      {{ $key }}: {{ $val | quote }}
+    {{- if and (not $values.rayStartParams) (not $values.initArgs) }}
+      {}
+    {{- else }}
+      {{- range $key, $val := $values.rayStartParams }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /*
+      initArgs is a deprecated alias for rayStartParams.
+      */}}
+      {{- range $key, $val := $values.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
     {{- end }}
     replicas: {{ $values.replicas }}
     minReplicas: {{ $values.minReplicas | default (default 1 $values.miniReplicas) }}
@@ -110,8 +121,8 @@ spec:
             {{- toYaml $values.securityContext | nindent 14 }}
             env:
             {{- toYaml $values.containerEnv | nindent 14}}
-            {{- with $values.envFrom }}
-            envFrom: {{- toYaml $ | nindent 14}}
+            {{- if $values.envFrom }}
+            envFrom: {{- toYaml $values.envFrom | nindent 14 }}
             {{- end }}
             ports: {{- toYaml $values.ports | nindent 14}}
             {{- if $values.lifecycle }}
@@ -144,14 +155,18 @@ spec:
   {{- end }}
   {{- if ne (.Values.worker.disabled | default false) true }}
   - rayStartParams:
-    {{- range $key, $val := .Values.worker.rayStartParams }}
-      {{ $key }}: {{ $val | quote }}
-    {{- end }}
-    {{- /*
-    initArgs is a deprecated alias for rayStartParams.
-    */}}
-    {{- range $key, $val := .Values.worker.initArgs }}
-      {{ $key }}: {{ $val | quote }}
+    {{- if and (not .Values.worker.rayStartParams) (not .Values.worker.initArgs) }}
+      {}
+    {{- else }}
+      {{- range $key, $val := .Values.worker.rayStartParams }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
+      {{- /*
+      initArgs is a deprecated alias for rayStartParams.
+      */}}
+      {{- range $key, $val := .Values.worker.initArgs }}
+        {{ $key }}: {{ $val | quote }}
+      {{- end }}
     {{- end }}
     replicas: {{ .Values.worker.replicas }}
     minReplicas: {{ .Values.worker.minReplicas | default (default 1 .Values.worker.miniReplicas) }}

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -7,7 +7,7 @@
 
 image:
   repository: rayproject/ray
-  tag: 2.3.0
+  tag: 2.4.0
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay"
@@ -19,7 +19,7 @@ imagePullSecrets: []
 head:
   # rayVersion determines the autoscaler's image version.
   # It should match the Ray version in the image of the containers.
-  # rayVersion: 2.3.0
+  # rayVersion: 2.4.0
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
@@ -46,6 +46,8 @@ head:
     #     cpu: "500m"
     #     memory: "512Mi"
   labels: {}
+  # Note: From KubeRay v0.6.0, users need to create the ServiceAccount by themselves if they specify the `serviceAccountName`
+  # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
   serviceAccountName: ""
   rayStartParams:
     dashboard-host: '0.0.0.0'
@@ -106,8 +108,7 @@ worker:
   replicas: 1
   labels: {}
   serviceAccountName: ""
-  rayStartParams:
-    block: 'true'
+  rayStartParams: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
@@ -167,8 +168,7 @@ additionalWorkerGroups:
     maxReplicas: 3
     labels: {}
     serviceAccountName: ""
-    rayStartParams:
-      block: 'true'
+    rayStartParams: {}
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
     containerEnv: []
@@ -218,3 +218,6 @@ additionalWorkerGroups:
 service:
   # This is optional, and the default is ClusterIP.
   type: ClusterIP
+  # Optional, for the user to provide any additional fields to the service.
+  # See https://pkg.go.dev/k8s.io/Kubernetes/pkg/api/v1#Service
+  headService: {}


### PR DESCRIPTION
Following the release process at https://github.com/ray-project/kuberay/blob/master/docs/release/helm-chart.md, this PR deletes the `helm-chart` directory and replaces it with the one from the tip of the 0.5.2 branch of kuberay. 

