### PR TITLE
release 0.6.1

### DIFF
--- a/helm-chart/kuberay-apiserver/Chart.yaml
+++ b/helm-chart/kuberay-apiserver/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -16,8 +16,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install the KubeRay API Server at Version v0.5.0.
-  helm install kuberay-apiserver kuberay/kuberay-apiserver --version 0.5.0
+  # Install the KubeRay API Server at Version v0.6.0.
+  helm install kuberay-apiserver kuberay/kuberay-apiserver --version 0.6.0
 
   # Check that the KubeRay API Server is running in the "default" namespaces.
   kubectl get pods
@@ -42,7 +42,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                      NAMESPACE       REVISION        UPDATED                                    STATUS         CHART
-# kuberay-apiserver         default         1               2022-12-02 02:13:37.514445313 +0000 UTC    deployed       kuberay-apiserver-0.5.0
+# kuberay-apiserver         default         1               2022-12-02 02:13:37.514445313 +0000 UTC    deployed       kuberay-apiserver-0.6.0
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: A Helm chart for Kubernetes
 name: kuberay-operator
-version: 0.6.0
+version: 0.6.1
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png
 type: application

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -16,8 +16,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v0.5.0.
-  helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
+  # Install both CRDs and KubeRay operator v0.6.0.
+  helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -40,10 +40,10 @@ helm version
   * Use Helm's built-in `--skip-crds` flag to install the operator only. See [this document](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/) for more details.
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.5.0&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/manifests/cluster-scope-resources?ref=v0.6.0&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0 --skip-crds
   ``` 
 
 ## List the chart
@@ -53,7 +53,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                   STATUS          CHART                   # APP VERSION
-# kuberay-operator        default         1               2022-12-02 02:13:37.514445313 +0000 UTC   deployed        kuberay-operator-0.5.0  1.0
+# kuberay-operator        default         1               2022-12-02 02:13:37.514445313 +0000 UTC   deployed        kuberay-operator-0.6.0  1.0
 ```
 
 ## Uninstall the Chart
@@ -83,7 +83,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v0.5.0
+    targetRevision: v0.6.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -103,7 +103,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v0.5.0
+    targetRevision: v0.6.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -18,6 +18,13 @@ spec:
         app.kubernetes.io/name: {{ include "kuberay-operator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: kuberay-operator
+        {{- if .Values.labels }}
+        {{- toYaml .Values.labels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.annotations }}
+      annotations:
+        {{- toYaml .Values.annotations | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: ray-cluster
-version: 0.6.0
+version: 0.6.1
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -16,15 +16,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v0.5.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 0.5.0
+# Step 3: Install both CRDs and KubeRay operator v0.6.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 0.6.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 0.5.0
+helm install raycluster kuberay/ray-cluster --version 0.6.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 0.5.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 0.6.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster 
 kubectl get pods


### PR DESCRIPTION
The changes in this release only affect the Helm chart itself, so we are not updating the image tags here. A user needs to set the labels and annotations for the KubeRay Pod to be compatible with their internal tool.