### PR TITLE
feat: add support for watchNamespace in kuberay-apiserver

### DIFF
--- a/helm-chart/kuberay-apiserver/templates/role.yaml
+++ b/helm-chart/kuberay-apiserver/templates/role.yaml
@@ -1,15 +1,19 @@
-
 {{- if .Values.rbacEnable }}
+# when we are installing in a single namespace, just iterate over a list of [.Release.Namespace] so we don't have to repeat the body of the rules in a different file
+{{- $watchNamespaces := ternary (default (list .Release.Namespace) .Values.watchNamespace) (list .Release.Namespace) .Values.singleNamespaceInstall }}
+{{- range $namespace := $watchNamespaces }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespaceInstall }}
+{{- if $.Values.singleNamespaceInstall }}
 kind: Role
 {{- else }}
 kind: ClusterRole
 {{- end }}
 metadata:
   labels:
-    app.kubernetes.io/name: {{ .Values.name }}
-  name: {{ .Values.name }}
+    app.kubernetes.io/name: {{ $.Values.name }}
+  name: {{ $.Values.name }}
+  namespace: {{ $namespace }}
 rules:
 - apiGroups:
   - ray.io
@@ -50,4 +54,5 @@ rules:
   verbs:
   - get
   - list
+{{- end }}
 {{- end }}

--- a/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
+++ b/helm-chart/kuberay-apiserver/templates/rolebinding.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.rbacEnable }}
-{{- if .Values.singleNamespaceInstall }}
+# when we are installing in a single namespace, just iterate over a list of [.Release.Namespace] so we don't have to repeat the body of the rules in a different file
+{{- $watchNamespaces := ternary (default (list .Release.Namespace) .Values.watchNamespace) (list .Release.Namespace) .Values.singleNamespaceInstall }}
+{{- range $namespace := $watchNamespaces }}
+---
+{{- if $.Values.singleNamespaceInstall }}
 kind: RoleBinding
 {{- else }}
 kind: ClusterRoleBinding
@@ -7,18 +11,20 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-{{ include "kuberay-apiserver.labels" . | indent 4 }}
-  name: {{ include "kuberay-apiserver.fullname" . }}
+{{ include "kuberay-apiserver.labels" $ | indent 4 }}
+  name: {{ include "kuberay-apiserver.fullname" $ }}
+  namespace: {{ $namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name  }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ $.Values.serviceAccount.name  }}
+  namespace: {{ $.Release.Namespace }}
 roleRef:
-  {{- if .Values.singleNamespaceInstall }}
+  {{- if $.Values.singleNamespaceInstall }}
   kind: Role
   {{- else }}
   kind: ClusterRole
   {{- end }}
-  name: {{ include "kuberay-apiserver.fullname" . }}
+  name: {{ include "kuberay-apiserver.fullname" $ }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -72,5 +72,14 @@ route:
 
 rbacEnable: true
 
-# the chart can be installed by users with permissions to a single namespace only
+# When singleNamespaceInstall is true:
+# - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
+#   the chart can be installed by users with permissions restricted to a single namespace.
+# - If "watchNamespace" is not set, the KubeRay apiserver will, by default, only able to view resources within its own namespace.
 singleNamespaceInstall: false
+
+# You can set watchNamespace to a list of namespaces that KubeRay apiserver should have permission to list CRDs for
+# if singleNamespaceInstall is false, this setting is ignored
+# watchNamespace:
+#   - n1
+#   - n2


### PR DESCRIPTION
addresses https://github.com/ray-project/kuberay-helm/issues/27

Add the support for kuberay-apiserver to also install role/rolebinding in a list of namespaces like kuberay-operator. Did it slightly differently from kuberay-operator so the rules section of the RBAC is shared instead of repeated to reduce the possible drift between the two files

I verified that this change does not change helm output for existing usecase
```
helm template test .  > prechange.yaml
helm template --set singleNamespaceInstall=true test .  > prechange_single.yaml
```
Applied this patch
```
helm template test .  > postchange.yaml
helm template --set singleNamespaceInstall=true test .  > postchange_single.yaml

$ diff prechange.yaml postchange.yaml
# expected, my helm .Release.Namespace is default so it's just being explicitly specified now
16a17
>   namespace: default
67a69
>   namespace: default
151a154,159


$ diff prechange_single.yaml postchange_single.yaml
16a17
>   namespace: default
67a69
>   namespace: default
151a154,159
```

And finally test the multi namespace feature work
```
helm template --set singleNamespaceInstall=true --set "watchNamespace={n1,n2}" test .

# Source: kuberay-apiserver/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
...
  name: kuberay-apiserver
  namespace: n1

# Source: kuberay-apiserver/templates/role.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
...
  name: kuberay-apiserver
  namespace: n2

# Source: kuberay-apiserver/templates/rolebinding.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
...
  name: test-kuberay-apiserver
  namespace: n1

# Source: kuberay-apiserver/templates/rolebinding.yaml
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
...
  name: test-kuberay-apiserver
  namespace: n2
```