### PR TITLE
add runtimeclassname for both ray head and worker pod

### DIFF
--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -66,6 +66,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
+        {{ with .Values.head.runtimeClassName }}
+        runtimeClassName: {{ . | quote }}
+        {{- end }}
         {{- with .Values.head.initContainers }}
         initContainers:
         {{- toYaml . | nindent 8 }}
@@ -192,6 +195,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
+        {{ with .Values.worker.runtimeClassName }}
+        runtimeClassName: {{ . | quote }}
+        {{- end }}
         {{- with .Values.worker.initContainers }}
         initContainers:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -232,6 +232,15 @@ tests:
           path: spec.headGroupSpec.template.metadata.annotations.key2
           value: value2
 
+  - it: Should set runtimeClassName when `head.runtimeClassName` is set
+    set:
+      head:
+        runtimeClassName: test-runtime-class
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.runtimeClassName
+          value: test-runtime-class
+
   - it: Should add init containers if `head.initContainers` is set
     set:
       head:
@@ -878,6 +887,15 @@ tests:
       - equal:
           path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.metadata.annotations.key2
           value: value2
+
+  - it: Should set runtimeClassName when `worker.runtimeClassName` is set
+    set:
+      worker:
+        runtimeClassName: test-runtime-class
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.runtimeClassName
+          value: test-runtime-class
 
   - it: Should add init containers if `worker.initContainers` is set
     set:


### PR DESCRIPTION
This PR adds `runtimeClassName` specification at the chart level. (e.g. `runtimeClassName: nvidia`) The example use case here is to inject GPU access (drivers, libraries, and devices) to either ray head or worker pods.

Unit tests are also added.

```
### Chart [ ray-cluster ] .

 PASS  Test RayCluster  tests/raycluster_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       99 passed, 99 total
Snapshot:    0 passed, 0 total
Time:        166.47875ms
```