### PR TITLE
sync kuberay helm charts for v1.6.0-rc.0

### DIFF
--- a/helm-chart/Makefile
+++ b/helm-chart/Makefile
@@ -63,6 +63,8 @@ helm-lint: ## Run Helm chart lint test.
 .PHONY: helm-docs
 helm-docs: helm-docs-plugin ## Generates markdown documentation for Helm charts from requirements and values files.
 	$(HELM_DOCS) --chart-search-root=$(WORKDIR) --chart-to-generate=$(KUBERAY_OPERATOR_CHART_PATH) --sort-values-order=file
+	$(HELM_DOCS) --chart-search-root=$(WORKDIR) --chart-to-generate=$(RAY_CLUSTER_CHART_PATH) --sort-values-order=file
+	$(HELM_DOCS) --chart-search-root=$(WORKDIR) --chart-to-generate=$(KUBERAY_APISERVER_CHART_PATH) --sort-values-order=file
 
 ##@ Dependencies
 

--- a/helm-chart/kuberay-apiserver/Chart.yaml
+++ b/helm-chart/kuberay-apiserver/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.2
+version: 1.6.0-rc.0

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -79,7 +79,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0-rc.0
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -1,6 +1,14 @@
-# KubeRay API Server
+# KubeRay APIServer
 
-This document provides instructions to install the KubeRay API Server with a Helm chart.
+![Version: 1.6.0-rc.0](https://img.shields.io/badge/Version-1.6.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A Helm chart for kuberay-apiserver
+
+## Introduction
+
+This document provides instructions to install the KubeRay APIServer with a Helm chart.
+KubeRay APIServer V2 is enabled by default, for more information,
+please refer to the [KubeRay APIServer V2 documentation].
 
 ## Helm
 
@@ -11,7 +19,7 @@ v3.9.4.
 helm version
 ```
 
-## Install KubeRay API Server
+## Install KubeRay APIServer
 
 ### Without security proxy
 
@@ -32,7 +40,7 @@ helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set s
 # Step2: Navigate to `helm-chart/kuberay-apiserver`
 cd helm-chart/kuberay-apiserver
 
-# Step3: Install the KubeRay apiserver
+# Step3: Install the KubeRay APIServer
 helm install kuberay-apiserver . --set security=null
 ```
 
@@ -55,7 +63,7 @@ helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
 # Step2: Navigate to `helm-chart/kuberay-apiserver`
 cd helm-chart/kuberay-apiserver
 
-# Step3: Install the KubeRay apiserver
+# Step3: Install the KubeRay APIServer
 helm install kuberay-apiserver .
 ```
 
@@ -70,8 +78,8 @@ To list the `kuberay-apiserver` release:
 
 ```sh
 helm ls
-# NAME                      NAMESPACE       REVISION        UPDATED                                    STATUS         CHART
-# kuberay-apiserver         default         1               2022-12-02 02:13:37.514445313 +0000 UTC    deployed       kuberay-apiserver-1.1.0
+# NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
 ```
 
 ## Uninstall the Chart
@@ -80,9 +88,49 @@ helm ls
 # Uninstall the `kuberay-apiserver` release
 helm uninstall kuberay-apiserver
 
-# The API Server Pod should be removed.
+# The APIServer Pod should be removed.
 kubectl get pods
 # No resources found in default namespace.
 ```
 
-[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml
+[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm.yaml
+[KubeRay APIServer V2 documentation]: https://github.com/ray-project/kuberay/blob/master/apiserversdk/README.md
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| replicaCount | int | `1` |  |
+| name | string | `"kuberay-apiserver"` |  |
+| image.repository | string | `"quay.io/kuberay/apiserver"` | Image repository. |
+| image.tag | string | `"v1.6.0-rc.0"` | Image tag. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| cors | string | `nil` |  |
+| labels | object | `{}` | Extra labels. |
+| annotations | object | `{}` | Extra annotations. |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| serviceAccount.name | string | `"kuberay-apiserver"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| containerPort[0].name | string | `"http"` |  |
+| containerPort[0].containerPort | int | `8888` |  |
+| containerPort[0].protocol | string | `"TCP"` |  |
+| containerPort[1].name | string | `"grpc"` |  |
+| containerPort[1].containerPort | int | `8887` |  |
+| containerPort[1].protocol | string | `"TCP"` |  |
+| resources | object | `{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"300m","memory":"300Mi"}}` | Resource requests and limits for containers. |
+| sidecarContainers | list | `[]` | Sidecar containers to run along with the main container. |
+| nodeSelector | object | `{}` | Node selector for pods. |
+| affinity | object | `{}` | Affinity for pods. |
+| tolerations | list | `[]` | Tolerations for pods. |
+| service.type | string | `"ClusterIP"` | Service type. |
+| service.ports | list | `[{"name":"http","port":8888,"protocol":"TCP","targetPort":8888},{"name":"rpc","port":8887,"protocol":"TCP","targetPort":8887}]` | Service port. |
+| ingress.enabled | bool | `false` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.tls | list | `[]` |  |
+| route.enabled | bool | `false` |  |
+| route.annotations | object | `{}` |  |
+| rbacEnable | bool | `true` | Install Default RBAC roles and bindings |
+| singleNamespaceInstall | bool | `false` | The chart can be installed by users with permissions to a single namespace only |
+| enableAPIServerV2 | bool | `true` | If set to true, APIServer v2 would be served on the same port as the APIServer v1. |
+| security.proxy | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/kuberay/security-proxy","tag":"nightly"}` | security proxy image. |
+| security.env | object | `{"ENABLE_GRPC":"true","GRPC_LOCAL_PORT":8987,"HTTP_LOCAL_PORT":8988,"SECURITY_PREFIX":"/","SECURITY_TOKEN":"12345"}` | security proxy environment variables. |

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -29,7 +29,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0 --set security=null
 ```
 
 - Install the nightly version
@@ -52,7 +52,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0
 ```
 
 - Install the nightly version
@@ -79,7 +79,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/README.md.gotmpl
+++ b/helm-chart/kuberay-apiserver/README.md.gotmpl
@@ -1,0 +1,104 @@
+# KubeRay APIServer
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Introduction
+
+This document provides instructions to install the KubeRay APIServer with a Helm chart.
+KubeRay APIServer V2 is enabled by default, for more information,
+please refer to the [KubeRay APIServer V2 documentation].
+
+
+## Helm
+
+Make sure the version of Helm is v3+. Currently, [existing CI tests] are based on Helm v3.4.1 and
+v3.9.4.
+
+```sh
+helm version
+```
+
+## Install KubeRay APIServer
+
+### Without security proxy
+
+- Install a stable version via Helm repository
+
+```sh
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+helm repo update
+# Install KubeRay APIServer without security proxy
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
+```
+
+- Install the nightly version
+
+```sh
+# Step1: Clone KubeRay repository
+
+# Step2: Navigate to `helm-chart/kuberay-apiserver`
+cd helm-chart/kuberay-apiserver
+
+# Step3: Install the KubeRay APIServer
+helm install kuberay-apiserver . --set security=null
+```
+
+### With security proxy
+
+- Install a stable version via Helm repository
+
+```sh
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+helm repo update
+# Install KubeRay APIServer
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
+```
+
+- Install the nightly version
+
+```sh
+# Step1: Clone KubeRay repository
+
+# Step2: Navigate to `helm-chart/kuberay-apiserver`
+cd helm-chart/kuberay-apiserver
+
+# Step3: Install the KubeRay APIServer
+helm install kuberay-apiserver .
+```
+
+> [!IMPORTANT]
+> If you receive an "Unauthorized" error when making a request, please add an
+> authorization header to the request: `-H 'Authorization: 12345'` or install the
+> APIServer without a security proxy.
+
+## List the chart
+
+To list the `kuberay-apiserver` release:
+
+```sh
+helm ls
+# NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
+```
+
+## Uninstall the Chart
+
+```sh
+# Uninstall the `kuberay-apiserver` release
+helm uninstall kuberay-apiserver
+
+# The APIServer Pod should be removed.
+kubectl get pods
+# No resources found in default namespace.
+```
+
+[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm.yaml
+[KubeRay APIServer V2 documentation]: https://github.com/ray-project/kuberay/blob/master/apiserversdk/README.md
+
+{{ template "chart.valuesSection" . }}

--- a/helm-chart/kuberay-apiserver/README.md.gotmpl
+++ b/helm-chart/kuberay-apiserver/README.md.gotmpl
@@ -84,7 +84,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0-rc.0
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/README.md.gotmpl
+++ b/helm-chart/kuberay-apiserver/README.md.gotmpl
@@ -34,7 +34,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0 --set security=null
 ```
 
 - Install the nightly version
@@ -57,7 +57,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0
 ```
 
 - Install the nightly version
@@ -84,7 +84,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/templates/ingress.yaml
+++ b/helm-chart/kuberay-apiserver/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kuberay-apiserver.fullname" . -}}
+{{- $svcName := printf "%s-service" $fullName -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -50,11 +51,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ $fullName }}
+                name: {{ $svcName }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $svcName }}
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}

--- a/helm-chart/kuberay-apiserver/templates/route.yaml
+++ b/helm-chart/kuberay-apiserver/templates/route.yaml
@@ -14,7 +14,7 @@ spec:
   subdomain: api-server-kuberay
   to:
     kind: Service
-    name: {{ .Values.name }}-service
+    name: {{ include "kuberay-apiserver.fullname" . }}-service
     weight: 100
   port:
     targetPort: http

--- a/helm-chart/kuberay-apiserver/templates/service.yaml
+++ b/helm-chart/kuberay-apiserver/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}-service
+  name: {{ include "kuberay-apiserver.fullname" . }}-service
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: kuberay-apiserver

--- a/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
@@ -57,3 +57,93 @@ tests:
           kind: Ingress
           name: kuberay-apiserver
           namespace: kuberay-system
+
+  - it: Should have ingress backend service name matching the service name
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kuberay-apiserver-service
+
+  - it: Should have ingress backend service name matching the service name when fullnameOverride is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      fullnameOverride: test-name
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: test-name-service
+
+  - it: Should have ingress backend service name matching the service name when nameOverride is set
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      nameOverride: custom-api
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kuberay-apiserver-custom-api-service
+
+  - it: Should have correct service name in all backend references with multiple hosts and paths
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: example.com
+            paths:
+              - path: /api
+                pathType: Prefix
+              - path: /health
+                pathType: Exact
+          - host: api.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+      service:
+        port: 8888
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: kuberay-apiserver-service
+      - equal:
+          path: spec.rules[0].http.paths[1].backend.service.name
+          value: kuberay-apiserver-service
+      - equal:
+          path: spec.rules[1].http.paths[0].backend.service.name
+          value: kuberay-apiserver-service

--- a/helm-chart/kuberay-apiserver/tests/route_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/route_test.yaml
@@ -41,3 +41,32 @@ tests:
       - equal:
           path: metadata.annotations.key2
           value: value2
+
+  - it: Should have route backend service name matching the service name
+    set:
+      route:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.to.name
+          value: kuberay-apiserver-service
+
+  - it: Should have route backend service name matching the service name when fullnameOverride is set
+    set:
+      fullnameOverride: test-name
+      route:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.to.name
+          value: test-name-service
+
+  - it: Should have route backend service name matching the service name when nameOverride is set
+    set:
+      nameOverride: custom-api
+      route:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.to.name
+          value: kuberay-apiserver-custom-api-service

--- a/helm-chart/kuberay-apiserver/tests/service_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/service_test.yaml
@@ -24,3 +24,23 @@ tests:
       - equal:
           path: spec.type
           value: NodePort
+
+  - it: Should have service name matching fullnameOverride when set
+    set:
+      fullnameOverride: test-name
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: test-name-service
+          namespace: kuberay-system
+
+  - it: Should have service name matching nameOverride when set
+    set:
+      nameOverride: custom-api
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: kuberay-apiserver-custom-api-service
+          namespace: kuberay-system

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -7,8 +7,11 @@ replicaCount: 1
 name: kuberay-apiserver
 
 image:
+  # -- Image repository.
   repository: quay.io/kuberay/apiserver
-  tag: v1.4.2
+  # -- Image tag.
+  tag: v1.6.0-rc.0
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
 
 # Uncomment allowOrigin to enable CORS
@@ -16,23 +19,20 @@ image:
 cors:
   # allowOrigin: "*"
 
-labels:
+# -- Extra labels.
+labels: {}
   # key1: value1
   # key2: value2
 
-annotations:
+# -- Extra annotations.
+annotations: {}
   # key1: value1
   # key2: value2
-
-## Install Default RBAC roles and bindings
-rbac:
-  create: true
-  apiVersion: v1
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created.
   create: true
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: kuberay-apiserver
 
@@ -44,6 +44,7 @@ containerPort:
   containerPort: 8887
   protocol: TCP
 
+# -- Resource requests and limits for containers.
 resources:
   limits:
     cpu: 500m
@@ -66,8 +67,9 @@ tolerations: []
 
 # Only one service type needs to be picked
 service:
-# ClusterIP service
+  # -- Service type.
   type: ClusterIP
+  # -- Service port.
   ports:
   - name: http
     protocol: TCP
@@ -84,27 +86,33 @@ service:
 ingress:
   enabled: false
   annotations: {}
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
   className: ""
   tls: []
 
+# openshift routes
 route:
   enabled: false
   annotations: {}
 
+# -- Install Default RBAC roles and bindings
 rbacEnable: true
 
-# the chart can be installed by users with permissions to a single namespace only
+# -- The chart can be installed by users with permissions to a single namespace only
 singleNamespaceInstall: false
 
-# If set to true, API server v2 would be served on the same port as the API server v1.
+# -- If set to true, APIServer v2 would be served on the same port as the APIServer v1.
 enableAPIServerV2: true
 
 # security definition. Comment it out if security is not required
 security:
+  # -- security proxy image.
   proxy:
     repository: quay.io/kuberay/security-proxy
     tag: nightly
     pullPolicy: IfNotPresent
+  # -- security proxy environment variables.
   env:
     HTTP_LOCAL_PORT: 8988
     GRPC_LOCAL_PORT: 8987

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -4,7 +4,7 @@ name: kuberay-operator
 
 description: A Helm chart for deploying the Kuberay operator on Kubernetes.
 
-version: 1.4.2
+version: 1.6.0-rc.0
 
 type: application
 

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -1,6 +1,6 @@
 # kuberay-operator
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.6.0-rc.0](https://img.shields.io/badge/Version-1.6.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the Kuberay operator on Kubernetes.
 
@@ -8,7 +8,7 @@ A Helm chart for deploying the Kuberay operator on Kubernetes.
 
 ## Introduction
 
-This document provides instructions to install both CRDs (RayCluster, RayJob, RayService) and
+This document provides instructions to install both CRDs (RayCluster, RayJob, RayService, RayCronJob) and
 KubeRay operator with a Helm chart.
 
 ## Prerequisites
@@ -29,8 +29,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.4.2.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2
+  # Install both CRDs and KubeRay operator v1.6.0-rc.0.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -58,10 +58,10 @@ helm version
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.2&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.6.0-rc.0&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0 --skip-crds
   ```
 
 ## List the chart
@@ -71,7 +71,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.2
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.6.0-rc.0
 ```
 
 ## Uninstall the Chart
@@ -102,7 +102,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.2
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -122,7 +122,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.2
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true
@@ -135,7 +135,7 @@ spec:
 ...
 ```
 
-[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml
+[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm.yaml
 [Argo CD]: https://argoproj.github.io
 [this issue]: https://github.com/prometheus-operator/prometheus-operator/issues/4439
 [this document]: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
@@ -147,11 +147,17 @@ spec:
 | nameOverride | string | `"kuberay-operator"` | String to partially override release name. |
 | fullnameOverride | string | `"kuberay-operator"` | String to fully override release name. |
 | componentOverride | string | `"kuberay-operator"` | String to override component name. |
+| replicas | int | `1` | Number of replicas for the KubeRay operator Deployment. |
 | image.repository | string | `"quay.io/kuberay/operator"` | Image repository. |
-| image.tag | string | `"v1.4.2"` | Image tag. |
+| image.tag | string | `"v1.6.0-rc.0"` | Image tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
+| nodeSelector | object | `{}` | Restrict to run on particular nodes. |
+| priorityClassName | string | `""` | Pod priorityClassName |
 | labels | object | `{}` | Extra labels. |
 | annotations | object | `{}` | Extra annotations. |
+| affinity | object | `{}` | Pod affinity |
+| tolerations | list | `[]` | Pod tolerations |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | serviceAccount.name | string | `"kuberay-operator"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
 | logging.stdoutEncoder | string | `"json"` | Log encoder to use for stdout (one of `json` or `console`). |
@@ -161,10 +167,20 @@ spec:
 | logging.sizeLimit | string | `""` | EmptyDir volume size limit for kuberay-operator log file. |
 | batchScheduler.enabled | bool | `false` |  |
 | batchScheduler.name | string | `""` |  |
+| configuration.enabled | bool | `false` | Whether to enable the configuration feature. If enabled, a ConfigMap will be created and mounted to the operator. When enabled, flag-based configuration values (leaderElectionEnabled, metrics.enabled, kubeClient.qps, etc.) will be injected into the ConfigMap. The operator will use the ConfigMap and ignore command-line flags. |
+| configuration.defaultContainerEnvs | list | `[]` | Default environment variables to inject into all Ray containers in all RayCluster CRs. This allows user to set feature flags across all Ray pods. Example: defaultContainerEnvs: - name: RAY_enable_open_telemetry   value: "true" - name: RAY_metric_cardinality_level   value: "recommended" |
+| configuration.headSidecarContainers | list | `[]` | Sidecar containers to inject into every Ray head pod. Example: headSidecarContainers: - name: fluentbit   image: fluent/fluent-bit:1.9 |
+| configuration.workerSidecarContainers | list | `[]` | Sidecar containers to inject into every Ray worker pod. Example: workerSidecarContainers: - name: fluentbit   image: fluent/fluent-bit:1.9 |
 | featureGates[0].name | string | `"RayClusterStatusConditions"` |  |
 | featureGates[0].enabled | bool | `true` |  |
 | featureGates[1].name | string | `"RayJobDeletionPolicy"` |  |
-| featureGates[1].enabled | bool | `false` |  |
+| featureGates[1].enabled | bool | `true` |  |
+| featureGates[2].name | string | `"RayMultiHostIndexing"` |  |
+| featureGates[2].enabled | bool | `true` |  |
+| featureGates[3].name | string | `"RayServiceIncrementalUpgrade"` |  |
+| featureGates[3].enabled | bool | `false` |  |
+| featureGates[4].name | string | `"RayCronJob"` |  |
+| featureGates[4].enabled | bool | `false` |  |
 | metrics.enabled | bool | `true` | Whether KubeRay operator should emit control plane metrics. |
 | metrics.serviceMonitor.enabled | bool | `false` | Enable a prometheus ServiceMonitor |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus ServiceMonitor interval |
@@ -173,6 +189,10 @@ spec:
 | metrics.serviceMonitor.namespace | string | `""` | Prometheus ServiceMonitor namespace |
 | operatorCommand | string | `"/manager"` | Path to the operator binary |
 | leaderElectionEnabled | bool | `true` | If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability. |
+| reconcileConcurrency | int | `1` | The maximum number of reconcile operations that can be performed simultaneously. This setting controls the concurrency of the controller reconciliation loops. Higher values can improve throughput in clusters with many resources, but may increase resource consumption. |
+| kubeClient | object | `{"burst":200,"qps":100}` | Kube Client configuration for QPS and burst settings. This setting controls the QPS and burst rate of the kube client when sending requests to the Kubernetes API server. If the QPS and burst values are too low, we may easily hit rate limits on the API server and slow down the controller reconciliation loops. |
+| kubeClient.qps | float | `100` | The QPS value for the client communicating with the Kubernetes API server. Must be a float number. |
+| kubeClient.burst | int | `200` | The maximum burst for throttling requests from this client to the Kubernetes API server. Must be a non-negative integer. |
 | rbacEnable | bool | `true` | If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on. |
 | crNamespacedRbacEnable | bool | `true` | When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services) and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable is set to false, the Role and RoleBinding for leader election will still be created.  Note: (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true. (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD. |
 | singleNamespaceInstall | bool | `false` | When singleNamespaceInstall is true: - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that   the chart can be installed by users with permissions restricted to a single namespace.   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.) - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen   to resource events within its own namespace. |

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -102,7 +102,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0-rc.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -122,7 +122,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0-rc.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -104,7 +104,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0-rc.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -124,7 +124,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0-rc.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -10,7 +10,7 @@
 
 ## Introduction
 
-This document provides instructions to install both CRDs (RayCluster, RayJob, RayService) and
+This document provides instructions to install both CRDs (RayCluster, RayJob, RayService, RayCronJob) and
 KubeRay operator with a Helm chart.
 
 ## Prerequisites
@@ -31,8 +31,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.4.2.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2
+  # Install both CRDs and KubeRay operator v{{ template "chart.version" . }}.
+  helm install kuberay-operator kuberay/kuberay-operator --version {{ template "chart.version" . }}
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -60,10 +60,10 @@ helm version
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.4.2&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v{{ template "chart.version" . }}&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.4.2 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version {{ template "chart.version" . }} --skip-crds
   ```
 
 ## List the chart
@@ -73,7 +73,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.4.2
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-{{ template "chart.version" . }}
 ```
 
 ## Uninstall the Chart
@@ -104,7 +104,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.2
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -124,7 +124,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.4.2
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true
@@ -137,7 +137,7 @@ spec:
 ...
 ```
 
-[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm-lint.yaml
+[existing CI tests]: https://github.com/ray-project/kuberay/blob/master/.github/workflows/helm.yaml
 [Argo CD]: https://argoproj.github.io
 [this issue]: https://github.com/prometheus-operator/prometheus-operator/issues/4439
 [this document]: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/

--- a/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayclusters.yaml
@@ -62,6 +62,18 @@ spec:
             type: object
           spec:
             properties:
+              authOptions:
+                properties:
+                  enableK8sTokenAuth:
+                    type: boolean
+                  mode:
+                    enum:
+                    - disabled
+                    - token
+                    type: string
+                  secretName:
+                    type: string
+                type: object
               autoscalerOptions:
                 properties:
                   env:
@@ -94,6 +106,23 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -338,6 +367,23 @@ spec:
                             - fieldPath
                             type: object
                             x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              optional:
+                                default: false
+                                type: boolean
+                              path:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - key
+                            - path
+                            - volumeName
+                            type: object
+                            x-kubernetes-map-type: atomic
                           resourceFieldRef:
                             properties:
                               containerName:
@@ -396,6 +442,23 @@ spec:
                                 type: string
                             required:
                             - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            properties:
+                              key:
+                                type: string
+                              optional:
+                                default: false
+                                type: boolean
+                              path:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - key
+                            - path
+                            - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -631,7 +694,15 @@ spec:
                             type: object
                         type: object
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
                   rayStartParams:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  resources:
                     additionalProperties:
                       type: string
                     type: object
@@ -1149,6 +1220,23 @@ spec:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
                                           resourceFieldRef:
                                             properties:
                                               containerName:
@@ -1577,6 +1665,29 @@ spec:
                                   type: object
                                 restartPolicy:
                                   type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -1861,6 +1972,23 @@ spec:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
                                           resourceFieldRef:
                                             properties:
                                               containerName:
@@ -2289,6 +2417,29 @@ spec:
                                   type: object
                                 restartPolicy:
                                   type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -2530,6 +2681,8 @@ spec:
                             type: boolean
                           hostname:
                             type: string
+                          hostnameOverride:
+                            type: string
                           imagePullSecrets:
                             items:
                               properties:
@@ -2585,6 +2738,23 @@ spec:
                                                 type: string
                                             required:
                                             - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
@@ -3015,6 +3185,29 @@ spec:
                                   type: object
                                 restartPolicy:
                                   type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -4111,6 +4304,29 @@ spec:
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                             type: object
+                                          podCertificate:
+                                            properties:
+                                              certificateChainPath:
+                                                type: string
+                                              credentialBundlePath:
+                                                type: string
+                                              keyPath:
+                                                type: string
+                                              keyType:
+                                                type: string
+                                              maxExpirationSeconds:
+                                                format: int32
+                                                type: integer
+                                              signerName:
+                                                type: string
+                                              userAnnotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            required:
+                                            - keyType
+                                            - signerName
+                                            type: object
                                           secret:
                                             properties:
                                               items:
@@ -4301,6 +4517,18 @@ spec:
                             x-kubernetes-list-map-keys:
                             - name
                             x-kubernetes-list-type: map
+                          workloadRef:
+                            properties:
+                              name:
+                                type: string
+                              podGroup:
+                                type: string
+                              podGroupReplicaKey:
+                                type: string
+                            required:
+                            - name
+                            - podGroup
+                            type: object
                         required:
                         - containers
                         type: object
@@ -4324,6 +4552,14 @@ spec:
                 type: string
               suspend:
                 type: boolean
+              upgradeStrategy:
+                properties:
+                  type:
+                    enum:
+                    - Recreate
+                    - None
+                    type: string
+                type: object
               workerGroupSpecs:
                 items:
                   properties:
@@ -4332,6 +4568,10 @@ spec:
                     idleTimeoutSeconds:
                       format: int32
                       type: integer
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     maxReplicas:
                       default: 2147483647
                       format: int32
@@ -4352,6 +4592,10 @@ spec:
                       default: 0
                       format: int32
                       type: integer
+                    resources:
+                      additionalProperties:
+                        type: string
+                      type: object
                     scaleStrategy:
                       properties:
                         workersToDelete:
@@ -4873,6 +5117,23 @@ spec:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -5301,6 +5562,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -5585,6 +5869,23 @@ spec:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -6013,6 +6314,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -6254,6 +6578,8 @@ spec:
                               type: boolean
                             hostname:
                               type: string
+                            hostnameOverride:
+                              type: string
                             imagePullSecrets:
                               items:
                                 properties:
@@ -6309,6 +6635,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -6739,6 +7082,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -7835,6 +8201,29 @@ spec:
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                               type: object
+                                            podCertificate:
+                                              properties:
+                                                certificateChainPath:
+                                                  type: string
+                                                credentialBundlePath:
+                                                  type: string
+                                                keyPath:
+                                                  type: string
+                                                keyType:
+                                                  type: string
+                                                maxExpirationSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                signerName:
+                                                  type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              required:
+                                              - keyType
+                                              - signerName
+                                              type: object
                                             secret:
                                               properties:
                                                 items:
@@ -8025,6 +8414,18 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              properties:
+                                name:
+                                  type: string
+                                podGroup:
+                                  type: string
+                                podGroupReplicaKey:
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -8234,6 +8635,23 @@ spec:
                                   type: string
                               required:
                               - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
@@ -9155,6 +9573,23 @@ spec:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
                                           resourceFieldRef:
                                             properties:
                                               containerName:
@@ -9583,6 +10018,29 @@ spec:
                                   type: object
                                 restartPolicy:
                                   type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -9867,6 +10325,23 @@ spec:
                                             - fieldPath
                                             type: object
                                             x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
                                           resourceFieldRef:
                                             properties:
                                               containerName:
@@ -10295,6 +10770,29 @@ spec:
                                   type: object
                                 restartPolicy:
                                   type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -10536,6 +11034,8 @@ spec:
                             type: boolean
                           hostname:
                             type: string
+                          hostnameOverride:
+                            type: string
                           imagePullSecrets:
                             items:
                               properties:
@@ -10591,6 +11091,23 @@ spec:
                                                 type: string
                                             required:
                                             - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           resourceFieldRef:
@@ -11021,6 +11538,29 @@ spec:
                                   type: object
                                 restartPolicy:
                                   type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                                 securityContext:
                                   properties:
                                     allowPrivilegeEscalation:
@@ -12117,6 +12657,29 @@ spec:
                                                 type: array
                                                 x-kubernetes-list-type: atomic
                                             type: object
+                                          podCertificate:
+                                            properties:
+                                              certificateChainPath:
+                                                type: string
+                                              credentialBundlePath:
+                                                type: string
+                                              keyPath:
+                                                type: string
+                                              keyType:
+                                                type: string
+                                              maxExpirationSeconds:
+                                                format: int32
+                                                type: integer
+                                              signerName:
+                                                type: string
+                                              userAnnotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            required:
+                                            - keyType
+                                            - signerName
+                                            type: object
                                           secret:
                                             properties:
                                               items:
@@ -12307,6 +12870,18 @@ spec:
                             x-kubernetes-list-map-keys:
                             - name
                             x-kubernetes-list-type: map
+                          workloadRef:
+                            properties:
+                              name:
+                                type: string
+                              podGroup:
+                                type: string
+                              podGroupReplicaKey:
+                                type: string
+                            required:
+                            - name
+                            - podGroup
+                            type: object
                         required:
                         - containers
                         type: object
@@ -12863,6 +13438,23 @@ spec:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -13291,6 +13883,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -13575,6 +14190,23 @@ spec:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -14003,6 +14635,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -14244,6 +14899,8 @@ spec:
                               type: boolean
                             hostname:
                               type: string
+                            hostnameOverride:
+                              type: string
                             imagePullSecrets:
                               items:
                                 properties:
@@ -14299,6 +14956,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -14729,6 +15403,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -15825,6 +16522,29 @@ spec:
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                               type: object
+                                            podCertificate:
+                                              properties:
+                                                certificateChainPath:
+                                                  type: string
+                                                credentialBundlePath:
+                                                  type: string
+                                                keyPath:
+                                                  type: string
+                                                keyType:
+                                                  type: string
+                                                maxExpirationSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                signerName:
+                                                  type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              required:
+                                              - keyType
+                                              - signerName
+                                              type: object
                                             secret:
                                               properties:
                                                 items:
@@ -16015,6 +16735,18 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              properties:
+                                name:
+                                  type: string
+                                podGroup:
+                                  type: string
+                                podGroupReplicaKey:
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object

--- a/helm-chart/kuberay-operator/crds/ray.io_raycronjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_raycronjobs.yaml
@@ -1,0 +1,12397 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: raycronjobs.ray.io
+spec:
+  group: ray.io
+  names:
+    categories:
+    - all
+    kind: RayCronJob
+    listKind: RayCronJobList
+    plural: raycronjobs
+    singular: raycronjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.schedule
+      name: schedule
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: last schedule
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    - jsonPath: .spec.suspend
+      name: suspend
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              jobTemplate:
+                properties:
+                  activeDeadlineSeconds:
+                    format: int32
+                    type: integer
+                  backoffLimit:
+                    default: 0
+                    format: int32
+                    type: integer
+                  clusterSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  deletionStrategy:
+                    properties:
+                      deletionRules:
+                        items:
+                          properties:
+                            condition:
+                              properties:
+                                jobDeploymentStatus:
+                                  enum:
+                                  - Failed
+                                  type: string
+                                jobStatus:
+                                  enum:
+                                  - SUCCEEDED
+                                  - FAILED
+                                  type: string
+                                ttlSeconds:
+                                  default: 0
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                              type: object
+                              x-kubernetes-validations:
+                              - message: JobStatus and JobDeploymentStatus cannot
+                                  be used together within the same deletion condition.
+                                rule: '!(has(self.jobStatus) && has(self.jobDeploymentStatus))'
+                              - message: the deletion condition requires either the
+                                  JobStatus or the JobDeploymentStatus field.
+                                rule: has(self.jobStatus) || has(self.jobDeploymentStatus)
+                            policy:
+                              enum:
+                              - DeleteCluster
+                              - DeleteWorkers
+                              - DeleteSelf
+                              - DeleteNone
+                              type: string
+                          required:
+                          - condition
+                          - policy
+                          type: object
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      onFailure:
+                        properties:
+                          policy:
+                            enum:
+                            - DeleteCluster
+                            - DeleteWorkers
+                            - DeleteSelf
+                            - DeleteNone
+                            type: string
+                        type: object
+                      onSuccess:
+                        properties:
+                          policy:
+                            enum:
+                            - DeleteCluster
+                            - DeleteWorkers
+                            - DeleteSelf
+                            - DeleteNone
+                            type: string
+                        type: object
+                    type: object
+                    x-kubernetes-validations:
+                    - message: legacy policies (onSuccess/onFailure) and deletionRules
+                        cannot be used together within the same deletionStrategy
+                      rule: '!((has(self.onSuccess) || has(self.onFailure)) && has(self.deletionRules))'
+                    - message: deletionStrategy requires either BOTH onSuccess and
+                        onFailure, OR the deletionRules field (cannot be empty)
+                      rule: ((has(self.onSuccess) && has(self.onFailure)) || has(self.deletionRules))
+                  entrypoint:
+                    type: string
+                  entrypointNumCpus:
+                    type: number
+                  entrypointNumGpus:
+                    type: number
+                  entrypointResources:
+                    type: string
+                  jobId:
+                    type: string
+                  managedBy:
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the managedBy field is immutable
+                      rule: self == oldSelf
+                    - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                        or 'kueue.x-k8s.io/multikueue'
+                      rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
+                  metadata:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  preRunningDeadlineSeconds:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  rayClusterSpec:
+                    properties:
+                      authOptions:
+                        properties:
+                          enableK8sTokenAuth:
+                            type: boolean
+                          mode:
+                            enum:
+                            - disabled
+                            - token
+                            type: string
+                          secretName:
+                            type: string
+                        type: object
+                      autoscalerOptions:
+                        properties:
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        optional:
+                                          default: false
+                                          type: boolean
+                                        path:
+                                          type: string
+                                        volumeName:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      - volumeName
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          default: ""
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                          idleTimeoutSeconds:
+                            format: int32
+                            type: integer
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    request:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          securityContext:
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              appArmorProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              capabilities:
+                                properties:
+                                  add:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  drop:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              privileged:
+                                type: boolean
+                              procMount:
+                                type: string
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  hostProcess:
+                                    type: boolean
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          upscalingMode:
+                            enum:
+                            - Default
+                            - Aggressive
+                            - Conservative
+                            type: string
+                          version:
+                            enum:
+                            - v1
+                            - v2
+                            type: string
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      enableInTreeAutoscaling:
+                        type: boolean
+                      gcsFaultToleranceOptions:
+                        properties:
+                          externalStorageNamespace:
+                            type: string
+                          redisAddress:
+                            type: string
+                          redisPassword:
+                            properties:
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      optional:
+                                        default: false
+                                        type: boolean
+                                      path:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            type: object
+                          redisUsername:
+                            properties:
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      optional:
+                                        default: false
+                                        type: boolean
+                                      path:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        default: ""
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            type: object
+                        required:
+                        - redisAddress
+                        type: object
+                      headGroupSpec:
+                        properties:
+                          enableIngress:
+                            type: boolean
+                          headService:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              spec:
+                                properties:
+                                  allocateLoadBalancerNodePorts:
+                                    type: boolean
+                                  clusterIP:
+                                    type: string
+                                  clusterIPs:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  externalIPs:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  externalName:
+                                    type: string
+                                  externalTrafficPolicy:
+                                    type: string
+                                  healthCheckNodePort:
+                                    format: int32
+                                    type: integer
+                                  internalTrafficPolicy:
+                                    type: string
+                                  ipFamilies:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  ipFamilyPolicy:
+                                    type: string
+                                  loadBalancerClass:
+                                    type: string
+                                  loadBalancerIP:
+                                    type: string
+                                  loadBalancerSourceRanges:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  ports:
+                                    items:
+                                      properties:
+                                        appProtocol:
+                                          type: string
+                                        name:
+                                          type: string
+                                        nodePort:
+                                          format: int32
+                                          type: integer
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        protocol:
+                                          default: TCP
+                                          type: string
+                                        targetPort:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - port
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  publishNotReadyAddresses:
+                                    type: boolean
+                                  selector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sessionAffinity:
+                                    type: string
+                                  sessionAffinityConfig:
+                                    properties:
+                                      clientIP:
+                                        properties:
+                                          timeoutSeconds:
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  trafficDistribution:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              status:
+                                properties:
+                                  conditions:
+                                    items:
+                                      properties:
+                                        lastTransitionTime:
+                                          format: date-time
+                                          type: string
+                                        message:
+                                          maxLength: 32768
+                                          type: string
+                                        observedGeneration:
+                                          format: int64
+                                          minimum: 0
+                                          type: integer
+                                        reason:
+                                          maxLength: 1024
+                                          minLength: 1
+                                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                          type: string
+                                        status:
+                                          enum:
+                                          - "True"
+                                          - "False"
+                                          - Unknown
+                                          type: string
+                                        type:
+                                          maxLength: 316
+                                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                          type: string
+                                      required:
+                                      - lastTransitionTime
+                                      - message
+                                      - reason
+                                      - status
+                                      - type
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - type
+                                    x-kubernetes-list-type: map
+                                  loadBalancer:
+                                    properties:
+                                      ingress:
+                                        items:
+                                          properties:
+                                            hostname:
+                                              type: string
+                                            ip:
+                                              type: string
+                                            ipMode:
+                                              type: string
+                                            ports:
+                                              items:
+                                                properties:
+                                                  error:
+                                                    maxLength: 316
+                                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                                    type: string
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  protocol:
+                                                    type: string
+                                                required:
+                                                - error
+                                                - port
+                                                - protocol
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                type: object
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          rayStartParams:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          resources:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          serviceType:
+                            type: string
+                          template:
+                            properties:
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              spec:
+                                properties:
+                                  activeDeadlineSeconds:
+                                    format: int64
+                                    type: integer
+                                  affinity:
+                                    properties:
+                                      nodeAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                preference:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            properties:
+                                              nodeSelectorTerms:
+                                                items:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      podAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    matchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    mismatchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podAntiAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    matchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    mismatchLabelKeys:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                    type: object
+                                  automountServiceAccountToken:
+                                    type: boolean
+                                  containers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fileKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      optional:
+                                                        default: false
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      volumeName:
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            stopSignal:
+                                              type: string
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resizePolicy:
+                                          items:
+                                            properties:
+                                              resourceName:
+                                                type: string
+                                              restartPolicy:
+                                                type: string
+                                            required:
+                                            - resourceName
+                                            - restartPolicy
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        restartPolicyRules:
+                                          items:
+                                            properties:
+                                              action:
+                                                type: string
+                                              exitCodes:
+                                                properties:
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      format: int32
+                                                      type: integer
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                required:
+                                                - operator
+                                                type: object
+                                            required:
+                                            - action
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - devicePath
+                                          x-kubernetes-list-type: map
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              recursiveReadOnly:
+                                                type: string
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - mountPath
+                                          x-kubernetes-list-type: map
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  dnsConfig:
+                                    properties:
+                                      nameservers:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      options:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      searches:
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  dnsPolicy:
+                                    type: string
+                                  enableServiceLinks:
+                                    type: boolean
+                                  ephemeralContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fileKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      optional:
+                                                        default: false
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      volumeName:
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            stopSignal:
+                                              type: string
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resizePolicy:
+                                          items:
+                                            properties:
+                                              resourceName:
+                                                type: string
+                                              restartPolicy:
+                                                type: string
+                                            required:
+                                            - resourceName
+                                            - restartPolicy
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        restartPolicyRules:
+                                          items:
+                                            properties:
+                                              action:
+                                                type: string
+                                              exitCodes:
+                                                properties:
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      format: int32
+                                                      type: integer
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                required:
+                                                - operator
+                                                type: object
+                                            required:
+                                            - action
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        targetContainerName:
+                                          type: string
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - devicePath
+                                          x-kubernetes-list-type: map
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              recursiveReadOnly:
+                                                type: string
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - mountPath
+                                          x-kubernetes-list-type: map
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  hostAliases:
+                                    items:
+                                      properties:
+                                        hostnames:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        ip:
+                                          type: string
+                                      required:
+                                      - ip
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - ip
+                                    x-kubernetes-list-type: map
+                                  hostIPC:
+                                    type: boolean
+                                  hostNetwork:
+                                    type: boolean
+                                  hostPID:
+                                    type: boolean
+                                  hostUsers:
+                                    type: boolean
+                                  hostname:
+                                    type: string
+                                  hostnameOverride:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  initContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fileKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      optional:
+                                                        default: false
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      volumeName:
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                sleep:
+                                                  properties:
+                                                    seconds:
+                                                      format: int64
+                                                      type: integer
+                                                  required:
+                                                  - seconds
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            stopSignal:
+                                              type: string
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resizePolicy:
+                                          items:
+                                            properties:
+                                              resourceName:
+                                                type: string
+                                              restartPolicy:
+                                                type: string
+                                            required:
+                                            - resourceName
+                                            - restartPolicy
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        restartPolicyRules:
+                                          items:
+                                            properties:
+                                              action:
+                                                type: string
+                                              exitCodes:
+                                                properties:
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      format: int32
+                                                      type: integer
+                                                    type: array
+                                                    x-kubernetes-list-type: set
+                                                required:
+                                                - operator
+                                                type: object
+                                            required:
+                                            - action
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  default: ""
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - devicePath
+                                          x-kubernetes-list-type: map
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              recursiveReadOnly:
+                                                type: string
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - mountPath
+                                          x-kubernetes-list-type: map
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  nodeName:
+                                    type: string
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  os:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  overhead:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  preemptionPolicy:
+                                    type: string
+                                  priority:
+                                    format: int32
+                                    type: integer
+                                  priorityClassName:
+                                    type: string
+                                  readinessGates:
+                                    items:
+                                      properties:
+                                        conditionType:
+                                          type: string
+                                      required:
+                                      - conditionType
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resourceClaims:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        resourceClaimName:
+                                          type: string
+                                        resourceClaimTemplateName:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  resources:
+                                    properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            request:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    type: string
+                                  runtimeClassName:
+                                    type: string
+                                  schedulerName:
+                                    type: string
+                                  schedulingGates:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  securityContext:
+                                    properties:
+                                      appArmorProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      fsGroup:
+                                        format: int64
+                                        type: integer
+                                      fsGroupChangePolicy:
+                                        type: string
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxChangePolicy:
+                                        type: string
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      supplementalGroups:
+                                        items:
+                                          format: int64
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      supplementalGroupsPolicy:
+                                        type: string
+                                      sysctls:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  serviceAccount:
+                                    type: string
+                                  serviceAccountName:
+                                    type: string
+                                  setHostnameAsFQDN:
+                                    type: boolean
+                                  shareProcessNamespace:
+                                    type: boolean
+                                  subdomain:
+                                    type: string
+                                  terminationGracePeriodSeconds:
+                                    format: int64
+                                    type: integer
+                                  tolerations:
+                                    items:
+                                      properties:
+                                        effect:
+                                          type: string
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        tolerationSeconds:
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologySpreadConstraints:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        maxSkew:
+                                          format: int32
+                                          type: integer
+                                        minDomains:
+                                          format: int32
+                                          type: integer
+                                        nodeAffinityPolicy:
+                                          type: string
+                                        nodeTaintsPolicy:
+                                          type: string
+                                        topologyKey:
+                                          type: string
+                                        whenUnsatisfiable:
+                                          type: string
+                                      required:
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - topologyKey
+                                    - whenUnsatisfiable
+                                    x-kubernetes-list-type: map
+                                  volumes:
+                                    items:
+                                      properties:
+                                        awsElasticBlockStore:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        azureDisk:
+                                          properties:
+                                            cachingMode:
+                                              type: string
+                                            diskName:
+                                              type: string
+                                            diskURI:
+                                              type: string
+                                            fsType:
+                                              default: ext4
+                                              type: string
+                                            kind:
+                                              type: string
+                                            readOnly:
+                                              default: false
+                                              type: boolean
+                                          required:
+                                          - diskName
+                                          - diskURI
+                                          type: object
+                                        azureFile:
+                                          properties:
+                                            readOnly:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                            shareName:
+                                              type: string
+                                          required:
+                                          - secretName
+                                          - shareName
+                                          type: object
+                                        cephfs:
+                                          properties:
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretFile:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            user:
+                                              type: string
+                                          required:
+                                          - monitors
+                                          type: object
+                                        cinder:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        configMap:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        csi:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            nodePublishSecretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            readOnly:
+                                              type: boolean
+                                            volumeAttributes:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          required:
+                                          - driver
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        emptyDir:
+                                          properties:
+                                            medium:
+                                              type: string
+                                            sizeLimit:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        ephemeral:
+                                          properties:
+                                            volumeClaimTemplate:
+                                              properties:
+                                                metadata:
+                                                  properties:
+                                                    annotations:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                    finalizers:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    labels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                    name:
+                                                      type: string
+                                                    namespace:
+                                                      type: string
+                                                  type: object
+                                                spec:
+                                                  properties:
+                                                    accessModes:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    dataSource:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    dataSourceRef:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                        namespace:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                    resources:
+                                                      properties:
+                                                        limits:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                        requests:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                      type: object
+                                                    selector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    storageClassName:
+                                                      type: string
+                                                    volumeAttributesClassName:
+                                                      type: string
+                                                    volumeMode:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  type: object
+                                              required:
+                                              - spec
+                                              type: object
+                                          type: object
+                                        fc:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            targetWWNs:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            wwids:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        flexVolume:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            options:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - driver
+                                          type: object
+                                        flocker:
+                                          properties:
+                                            datasetName:
+                                              type: string
+                                            datasetUUID:
+                                              type: string
+                                          type: object
+                                        gcePersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            pdName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - pdName
+                                          type: object
+                                        gitRepo:
+                                          properties:
+                                            directory:
+                                              type: string
+                                            repository:
+                                              type: string
+                                            revision:
+                                              type: string
+                                          required:
+                                          - repository
+                                          type: object
+                                        glusterfs:
+                                          properties:
+                                            endpoints:
+                                              type: string
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - endpoints
+                                          - path
+                                          type: object
+                                        hostPath:
+                                          properties:
+                                            path:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                        image:
+                                          properties:
+                                            pullPolicy:
+                                              type: string
+                                            reference:
+                                              type: string
+                                          type: object
+                                        iscsi:
+                                          properties:
+                                            chapAuthDiscovery:
+                                              type: boolean
+                                            chapAuthSession:
+                                              type: boolean
+                                            fsType:
+                                              type: string
+                                            initiatorName:
+                                              type: string
+                                            iqn:
+                                              type: string
+                                            iscsiInterface:
+                                              default: default
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            portals:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            targetPortal:
+                                              type: string
+                                          required:
+                                          - iqn
+                                          - lun
+                                          - targetPortal
+                                          type: object
+                                        name:
+                                          type: string
+                                        nfs:
+                                          properties:
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            server:
+                                              type: string
+                                          required:
+                                          - path
+                                          - server
+                                          type: object
+                                        persistentVolumeClaim:
+                                          properties:
+                                            claimName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - claimName
+                                          type: object
+                                        photonPersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            pdID:
+                                              type: string
+                                          required:
+                                          - pdID
+                                          type: object
+                                        portworxVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        projected:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            sources:
+                                              items:
+                                                properties:
+                                                  clusterTrustBundle:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                      path:
+                                                        type: string
+                                                      signerName:
+                                                        type: string
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  configMap:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  downwardAPI:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            fieldRef:
+                                                              properties:
+                                                                apiVersion:
+                                                                  type: string
+                                                                fieldPath:
+                                                                  type: string
+                                                              required:
+                                                              - fieldPath
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                            resourceFieldRef:
+                                                              properties:
+                                                                containerName:
+                                                                  type: string
+                                                                divisor:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                resource:
+                                                                  type: string
+                                                              required:
+                                                              - resource
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          required:
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  podCertificate:
+                                                    properties:
+                                                      certificateChainPath:
+                                                        type: string
+                                                      credentialBundlePath:
+                                                        type: string
+                                                      keyPath:
+                                                        type: string
+                                                      keyType:
+                                                        type: string
+                                                      maxExpirationSeconds:
+                                                        format: int32
+                                                        type: integer
+                                                      signerName:
+                                                        type: string
+                                                      userAnnotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    required:
+                                                    - keyType
+                                                    - signerName
+                                                    type: object
+                                                  secret:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      name:
+                                                        default: ""
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  serviceAccountToken:
+                                                    properties:
+                                                      audience:
+                                                        type: string
+                                                      expirationSeconds:
+                                                        format: int64
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        quobyte:
+                                          properties:
+                                            group:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            registry:
+                                              type: string
+                                            tenant:
+                                              type: string
+                                            user:
+                                              type: string
+                                            volume:
+                                              type: string
+                                          required:
+                                          - registry
+                                          - volume
+                                          type: object
+                                        rbd:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            image:
+                                              type: string
+                                            keyring:
+                                              default: /etc/ceph/keyring
+                                              type: string
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            pool:
+                                              default: rbd
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            user:
+                                              default: admin
+                                              type: string
+                                          required:
+                                          - image
+                                          - monitors
+                                          type: object
+                                        scaleIO:
+                                          properties:
+                                            fsType:
+                                              default: xfs
+                                              type: string
+                                            gateway:
+                                              type: string
+                                            protectionDomain:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            sslEnabled:
+                                              type: boolean
+                                            storageMode:
+                                              default: ThinProvisioned
+                                              type: string
+                                            storagePool:
+                                              type: string
+                                            system:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                          - gateway
+                                          - secretRef
+                                          - system
+                                          type: object
+                                        secret:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            optional:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                          type: object
+                                        storageos:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            volumeName:
+                                              type: string
+                                            volumeNamespace:
+                                              type: string
+                                          type: object
+                                        vsphereVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            storagePolicyID:
+                                              type: string
+                                            storagePolicyName:
+                                              type: string
+                                            volumePath:
+                                              type: string
+                                          required:
+                                          - volumePath
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  workloadRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                      podGroup:
+                                        type: string
+                                      podGroupReplicaKey:
+                                        type: string
+                                    required:
+                                    - name
+                                    - podGroup
+                                    type: object
+                                required:
+                                - containers
+                                type: object
+                            type: object
+                        required:
+                        - template
+                        type: object
+                      headServiceAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      managedBy:
+                        type: string
+                        x-kubernetes-validations:
+                        - message: the managedBy field is immutable
+                          rule: self == oldSelf
+                        - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                            or 'kueue.x-k8s.io/multikueue'
+                          rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
+                      rayVersion:
+                        type: string
+                      suspend:
+                        type: boolean
+                      upgradeStrategy:
+                        properties:
+                          type:
+                            enum:
+                            - Recreate
+                            - None
+                            type: string
+                        type: object
+                      workerGroupSpecs:
+                        items:
+                          properties:
+                            groupName:
+                              type: string
+                            idleTimeoutSeconds:
+                              format: int32
+                              type: integer
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            maxReplicas:
+                              default: 2147483647
+                              format: int32
+                              type: integer
+                            minReplicas:
+                              default: 0
+                              format: int32
+                              type: integer
+                            numOfHosts:
+                              default: 1
+                              format: int32
+                              type: integer
+                            rayStartParams:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            replicas:
+                              default: 0
+                              format: int32
+                              type: integer
+                            resources:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            scaleStrategy:
+                              properties:
+                                workersToDelete:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            suspend:
+                              type: boolean
+                            template:
+                              properties:
+                                metadata:
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    finalizers:
+                                      items:
+                                        type: string
+                                      type: array
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  type: object
+                                spec:
+                                  properties:
+                                    activeDeadlineSeconds:
+                                      format: int64
+                                      type: integer
+                                    affinity:
+                                      properties:
+                                        nodeAffinity:
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  preference:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                - preference
+                                                - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  items:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - nodeSelectorTerms
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        podAffinity:
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  podAffinityTerm:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                - podAffinityTerm
+                                                - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        podAntiAffinity:
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  podAffinityTerm:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                - podAffinityTerm
+                                                - weight
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              items:
+                                                properties:
+                                                  labelSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    properties:
+                                                      matchExpressions:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            operator:
+                                                              type: string
+                                                            values:
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                      type: object
+                                    automountServiceAccountToken:
+                                      type: boolean
+                                    containers:
+                                      items:
+                                        properties:
+                                          args:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          env:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fileKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        optional:
+                                                          default: false
+                                                          type: boolean
+                                                        path:
+                                                          type: string
+                                                        volumeName:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      - volumeName
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - name
+                                            x-kubernetes-list-type: map
+                                          envFrom:
+                                            items:
+                                              properties:
+                                                configMapRef:
+                                                  properties:
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                prefix:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          image:
+                                            type: string
+                                          imagePullPolicy:
+                                            type: string
+                                          lifecycle:
+                                            properties:
+                                              postStart:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    properties:
+                                                      seconds:
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    properties:
+                                                      seconds:
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              stopSignal:
+                                                type: string
+                                            type: object
+                                          livenessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            type: string
+                                          ports:
+                                            items:
+                                              properties:
+                                                containerPort:
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  type: string
+                                                hostPort:
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  type: string
+                                              required:
+                                              - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - containerPort
+                                            - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resizePolicy:
+                                            items:
+                                              properties:
+                                                resourceName:
+                                                  type: string
+                                                restartPolicy:
+                                                  type: string
+                                              required:
+                                              - resourceName
+                                              - restartPolicy
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    request:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          restartPolicy:
+                                            type: string
+                                          restartPolicyRules:
+                                            items:
+                                              properties:
+                                                action:
+                                                  type: string
+                                                exitCodes:
+                                                  properties:
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        format: int32
+                                                        type: integer
+                                                      type: array
+                                                      x-kubernetes-list-type: set
+                                                  required:
+                                                  - operator
+                                                  type: object
+                                              required:
+                                              - action
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          securityContext:
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                type: boolean
+                                              appArmorProfile:
+                                                properties:
+                                                  localhostProfile:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              capabilities:
+                                                properties:
+                                                  add:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  drop:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              privileged:
+                                                type: boolean
+                                              procMount:
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                type: boolean
+                                              runAsGroup:
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                type: boolean
+                                              runAsUser:
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                properties:
+                                                  level:
+                                                    type: string
+                                                  role:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                properties:
+                                                  localhostProfile:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  hostProcess:
+                                                    type: boolean
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            type: boolean
+                                          stdinOnce:
+                                            type: boolean
+                                          terminationMessagePath:
+                                            type: string
+                                          terminationMessagePolicy:
+                                            type: string
+                                          tty:
+                                            type: boolean
+                                          volumeDevices:
+                                            items:
+                                              properties:
+                                                devicePath:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                              - devicePath
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - devicePath
+                                            x-kubernetes-list-type: map
+                                          volumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                recursiveReadOnly:
+                                                  type: string
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                              - mountPath
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - mountPath
+                                            x-kubernetes-list-type: map
+                                          workingDir:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    dnsConfig:
+                                      properties:
+                                        nameservers:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        options:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        searches:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    dnsPolicy:
+                                      type: string
+                                    enableServiceLinks:
+                                      type: boolean
+                                    ephemeralContainers:
+                                      items:
+                                        properties:
+                                          args:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          env:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fileKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        optional:
+                                                          default: false
+                                                          type: boolean
+                                                        path:
+                                                          type: string
+                                                        volumeName:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      - volumeName
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - name
+                                            x-kubernetes-list-type: map
+                                          envFrom:
+                                            items:
+                                              properties:
+                                                configMapRef:
+                                                  properties:
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                prefix:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          image:
+                                            type: string
+                                          imagePullPolicy:
+                                            type: string
+                                          lifecycle:
+                                            properties:
+                                              postStart:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    properties:
+                                                      seconds:
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    properties:
+                                                      seconds:
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              stopSignal:
+                                                type: string
+                                            type: object
+                                          livenessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            type: string
+                                          ports:
+                                            items:
+                                              properties:
+                                                containerPort:
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  type: string
+                                                hostPort:
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  type: string
+                                              required:
+                                              - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - containerPort
+                                            - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resizePolicy:
+                                            items:
+                                              properties:
+                                                resourceName:
+                                                  type: string
+                                                restartPolicy:
+                                                  type: string
+                                              required:
+                                              - resourceName
+                                              - restartPolicy
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    request:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          restartPolicy:
+                                            type: string
+                                          restartPolicyRules:
+                                            items:
+                                              properties:
+                                                action:
+                                                  type: string
+                                                exitCodes:
+                                                  properties:
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        format: int32
+                                                        type: integer
+                                                      type: array
+                                                      x-kubernetes-list-type: set
+                                                  required:
+                                                  - operator
+                                                  type: object
+                                              required:
+                                              - action
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          securityContext:
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                type: boolean
+                                              appArmorProfile:
+                                                properties:
+                                                  localhostProfile:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              capabilities:
+                                                properties:
+                                                  add:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  drop:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              privileged:
+                                                type: boolean
+                                              procMount:
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                type: boolean
+                                              runAsGroup:
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                type: boolean
+                                              runAsUser:
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                properties:
+                                                  level:
+                                                    type: string
+                                                  role:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                properties:
+                                                  localhostProfile:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  hostProcess:
+                                                    type: boolean
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            type: boolean
+                                          stdinOnce:
+                                            type: boolean
+                                          targetContainerName:
+                                            type: string
+                                          terminationMessagePath:
+                                            type: string
+                                          terminationMessagePolicy:
+                                            type: string
+                                          tty:
+                                            type: boolean
+                                          volumeDevices:
+                                            items:
+                                              properties:
+                                                devicePath:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                              - devicePath
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - devicePath
+                                            x-kubernetes-list-type: map
+                                          volumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                recursiveReadOnly:
+                                                  type: string
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                              - mountPath
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - mountPath
+                                            x-kubernetes-list-type: map
+                                          workingDir:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    hostAliases:
+                                      items:
+                                        properties:
+                                          hostnames:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          ip:
+                                            type: string
+                                        required:
+                                        - ip
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - ip
+                                      x-kubernetes-list-type: map
+                                    hostIPC:
+                                      type: boolean
+                                    hostNetwork:
+                                      type: boolean
+                                    hostPID:
+                                      type: boolean
+                                    hostUsers:
+                                      type: boolean
+                                    hostname:
+                                      type: string
+                                    hostnameOverride:
+                                      type: string
+                                    imagePullSecrets:
+                                      items:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    initContainers:
+                                      items:
+                                        properties:
+                                          args:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          env:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                                valueFrom:
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fileKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        optional:
+                                                          default: false
+                                                          type: boolean
+                                                        path:
+                                                          type: string
+                                                        volumeName:
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      - volumeName
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - name
+                                            x-kubernetes-list-type: map
+                                          envFrom:
+                                            items:
+                                              properties:
+                                                configMapRef:
+                                                  properties:
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                prefix:
+                                                  type: string
+                                                secretRef:
+                                                  properties:
+                                                    name:
+                                                      default: ""
+                                                      type: string
+                                                    optional:
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          image:
+                                            type: string
+                                          imagePullPolicy:
+                                            type: string
+                                          lifecycle:
+                                            properties:
+                                              postStart:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    properties:
+                                                      seconds:
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    properties:
+                                                      seconds:
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              stopSignal:
+                                                type: string
+                                            type: object
+                                          livenessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            type: string
+                                          ports:
+                                            items:
+                                              properties:
+                                                containerPort:
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  type: string
+                                                hostPort:
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  type: string
+                                              required:
+                                              - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - containerPort
+                                            - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resizePolicy:
+                                            items:
+                                              properties:
+                                                resourceName:
+                                                  type: string
+                                                restartPolicy:
+                                                  type: string
+                                              required:
+                                              - resourceName
+                                              - restartPolicy
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          resources:
+                                            properties:
+                                              claims:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    request:
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                type: object
+                                            type: object
+                                          restartPolicy:
+                                            type: string
+                                          restartPolicyRules:
+                                            items:
+                                              properties:
+                                                action:
+                                                  type: string
+                                                exitCodes:
+                                                  properties:
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        format: int32
+                                                        type: integer
+                                                      type: array
+                                                      x-kubernetes-list-type: set
+                                                  required:
+                                                  - operator
+                                                  type: object
+                                              required:
+                                              - action
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          securityContext:
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                type: boolean
+                                              appArmorProfile:
+                                                properties:
+                                                  localhostProfile:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              capabilities:
+                                                properties:
+                                                  add:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  drop:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              privileged:
+                                                type: boolean
+                                              procMount:
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                type: boolean
+                                              runAsGroup:
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                type: boolean
+                                              runAsUser:
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                properties:
+                                                  level:
+                                                    type: string
+                                                  role:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                  user:
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                properties:
+                                                  localhostProfile:
+                                                    type: string
+                                                  type:
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              windowsOptions:
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    type: string
+                                                  hostProcess:
+                                                    type: boolean
+                                                  runAsUserName:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            properties:
+                                              exec:
+                                                properties:
+                                                  command:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              failureThreshold:
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    default: ""
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  httpHeaders:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        value:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                properties:
+                                                  host:
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            type: boolean
+                                          stdinOnce:
+                                            type: boolean
+                                          terminationMessagePath:
+                                            type: string
+                                          terminationMessagePolicy:
+                                            type: string
+                                          tty:
+                                            type: boolean
+                                          volumeDevices:
+                                            items:
+                                              properties:
+                                                devicePath:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                              - devicePath
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - devicePath
+                                            x-kubernetes-list-type: map
+                                          volumeMounts:
+                                            items:
+                                              properties:
+                                                mountPath:
+                                                  type: string
+                                                mountPropagation:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                readOnly:
+                                                  type: boolean
+                                                recursiveReadOnly:
+                                                  type: string
+                                                subPath:
+                                                  type: string
+                                                subPathExpr:
+                                                  type: string
+                                              required:
+                                              - mountPath
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - mountPath
+                                            x-kubernetes-list-type: map
+                                          workingDir:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    nodeName:
+                                      type: string
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    os:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    overhead:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    preemptionPolicy:
+                                      type: string
+                                    priority:
+                                      format: int32
+                                      type: integer
+                                    priorityClassName:
+                                      type: string
+                                    readinessGates:
+                                      items:
+                                        properties:
+                                          conditionType:
+                                            type: string
+                                        required:
+                                        - conditionType
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resourceClaims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          resourceClaimName:
+                                            type: string
+                                          resourceClaimTemplateName:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    resources:
+                                      properties:
+                                        claims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              request:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      type: string
+                                    runtimeClassName:
+                                      type: string
+                                    schedulerName:
+                                      type: string
+                                    schedulingGates:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    securityContext:
+                                      properties:
+                                        appArmorProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        fsGroup:
+                                          format: int64
+                                          type: integer
+                                        fsGroupChangePolicy:
+                                          type: string
+                                        runAsGroup:
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          type: boolean
+                                        runAsUser:
+                                          format: int64
+                                          type: integer
+                                        seLinuxChangePolicy:
+                                          type: string
+                                        seLinuxOptions:
+                                          properties:
+                                            level:
+                                              type: string
+                                            role:
+                                              type: string
+                                            type:
+                                              type: string
+                                            user:
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          properties:
+                                            localhostProfile:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        supplementalGroups:
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        supplementalGroupsPolicy:
+                                          type: string
+                                        sysctls:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        windowsOptions:
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              type: string
+                                            hostProcess:
+                                              type: boolean
+                                            runAsUserName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    serviceAccount:
+                                      type: string
+                                    serviceAccountName:
+                                      type: string
+                                    setHostnameAsFQDN:
+                                      type: boolean
+                                    shareProcessNamespace:
+                                      type: boolean
+                                    subdomain:
+                                      type: string
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    tolerations:
+                                      items:
+                                        properties:
+                                          effect:
+                                            type: string
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          tolerationSeconds:
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologySpreadConstraints:
+                                      items:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          maxSkew:
+                                            format: int32
+                                            type: integer
+                                          minDomains:
+                                            format: int32
+                                            type: integer
+                                          nodeAffinityPolicy:
+                                            type: string
+                                          nodeTaintsPolicy:
+                                            type: string
+                                          topologyKey:
+                                            type: string
+                                          whenUnsatisfiable:
+                                            type: string
+                                        required:
+                                        - maxSkew
+                                        - topologyKey
+                                        - whenUnsatisfiable
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                      x-kubernetes-list-type: map
+                                    volumes:
+                                      items:
+                                        properties:
+                                          awsElasticBlockStore:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              partition:
+                                                format: int32
+                                                type: integer
+                                              readOnly:
+                                                type: boolean
+                                              volumeID:
+                                                type: string
+                                            required:
+                                            - volumeID
+                                            type: object
+                                          azureDisk:
+                                            properties:
+                                              cachingMode:
+                                                type: string
+                                              diskName:
+                                                type: string
+                                              diskURI:
+                                                type: string
+                                              fsType:
+                                                default: ext4
+                                                type: string
+                                              kind:
+                                                type: string
+                                              readOnly:
+                                                default: false
+                                                type: boolean
+                                            required:
+                                            - diskName
+                                            - diskURI
+                                            type: object
+                                          azureFile:
+                                            properties:
+                                              readOnly:
+                                                type: boolean
+                                              secretName:
+                                                type: string
+                                              shareName:
+                                                type: string
+                                            required:
+                                            - secretName
+                                            - shareName
+                                            type: object
+                                          cephfs:
+                                            properties:
+                                              monitors:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretFile:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              user:
+                                                type: string
+                                            required:
+                                            - monitors
+                                            type: object
+                                          cinder:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              volumeID:
+                                                type: string
+                                            required:
+                                            - volumeID
+                                            type: object
+                                          configMap:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          csi:
+                                            properties:
+                                              driver:
+                                                type: string
+                                              fsType:
+                                                type: string
+                                              nodePublishSecretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              readOnly:
+                                                type: boolean
+                                              volumeAttributes:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            required:
+                                            - driver
+                                            type: object
+                                          downwardAPI:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                items:
+                                                  properties:
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          emptyDir:
+                                            properties:
+                                              medium:
+                                                type: string
+                                              sizeLimit:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          ephemeral:
+                                            properties:
+                                              volumeClaimTemplate:
+                                                properties:
+                                                  metadata:
+                                                    properties:
+                                                      annotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      finalizers:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      labels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                    type: object
+                                                  spec:
+                                                    properties:
+                                                      accessModes:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      dataSource:
+                                                        properties:
+                                                          apiGroup:
+                                                            type: string
+                                                          kind:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                        required:
+                                                        - kind
+                                                        - name
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      dataSourceRef:
+                                                        properties:
+                                                          apiGroup:
+                                                            type: string
+                                                          kind:
+                                                            type: string
+                                                          name:
+                                                            type: string
+                                                          namespace:
+                                                            type: string
+                                                        required:
+                                                        - kind
+                                                        - name
+                                                        type: object
+                                                      resources:
+                                                        properties:
+                                                          limits:
+                                                            additionalProperties:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            type: object
+                                                          requests:
+                                                            additionalProperties:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            type: object
+                                                        type: object
+                                                      selector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      storageClassName:
+                                                        type: string
+                                                      volumeAttributesClassName:
+                                                        type: string
+                                                      volumeMode:
+                                                        type: string
+                                                      volumeName:
+                                                        type: string
+                                                    type: object
+                                                required:
+                                                - spec
+                                                type: object
+                                            type: object
+                                          fc:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              lun:
+                                                format: int32
+                                                type: integer
+                                              readOnly:
+                                                type: boolean
+                                              targetWWNs:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              wwids:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          flexVolume:
+                                            properties:
+                                              driver:
+                                                type: string
+                                              fsType:
+                                                type: string
+                                              options:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - driver
+                                            type: object
+                                          flocker:
+                                            properties:
+                                              datasetName:
+                                                type: string
+                                              datasetUUID:
+                                                type: string
+                                            type: object
+                                          gcePersistentDisk:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              partition:
+                                                format: int32
+                                                type: integer
+                                              pdName:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                            required:
+                                            - pdName
+                                            type: object
+                                          gitRepo:
+                                            properties:
+                                              directory:
+                                                type: string
+                                              repository:
+                                                type: string
+                                              revision:
+                                                type: string
+                                            required:
+                                            - repository
+                                            type: object
+                                          glusterfs:
+                                            properties:
+                                              endpoints:
+                                                type: string
+                                              path:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                            required:
+                                            - endpoints
+                                            - path
+                                            type: object
+                                          hostPath:
+                                            properties:
+                                              path:
+                                                type: string
+                                              type:
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                          image:
+                                            properties:
+                                              pullPolicy:
+                                                type: string
+                                              reference:
+                                                type: string
+                                            type: object
+                                          iscsi:
+                                            properties:
+                                              chapAuthDiscovery:
+                                                type: boolean
+                                              chapAuthSession:
+                                                type: boolean
+                                              fsType:
+                                                type: string
+                                              initiatorName:
+                                                type: string
+                                              iqn:
+                                                type: string
+                                              iscsiInterface:
+                                                default: default
+                                                type: string
+                                              lun:
+                                                format: int32
+                                                type: integer
+                                              portals:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              targetPortal:
+                                                type: string
+                                            required:
+                                            - iqn
+                                            - lun
+                                            - targetPortal
+                                            type: object
+                                          name:
+                                            type: string
+                                          nfs:
+                                            properties:
+                                              path:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              server:
+                                                type: string
+                                            required:
+                                            - path
+                                            - server
+                                            type: object
+                                          persistentVolumeClaim:
+                                            properties:
+                                              claimName:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                            required:
+                                            - claimName
+                                            type: object
+                                          photonPersistentDisk:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              pdID:
+                                                type: string
+                                            required:
+                                            - pdID
+                                            type: object
+                                          portworxVolume:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              volumeID:
+                                                type: string
+                                            required:
+                                            - volumeID
+                                            type: object
+                                          projected:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              sources:
+                                                items:
+                                                  properties:
+                                                    clusterTrustBundle:
+                                                      properties:
+                                                        labelSelector:
+                                                          properties:
+                                                            matchExpressions:
+                                                              items:
+                                                                properties:
+                                                                  key:
+                                                                    type: string
+                                                                  operator:
+                                                                    type: string
+                                                                  values:
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                    x-kubernetes-list-type: atomic
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        name:
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                        path:
+                                                          type: string
+                                                        signerName:
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    configMap:
+                                                      properties:
+                                                        items:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              mode:
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                type: string
+                                                            required:
+                                                            - key
+                                                            - path
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    downwardAPI:
+                                                      properties:
+                                                        items:
+                                                          items:
+                                                            properties:
+                                                              fieldRef:
+                                                                properties:
+                                                                  apiVersion:
+                                                                    type: string
+                                                                  fieldPath:
+                                                                    type: string
+                                                                required:
+                                                                - fieldPath
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                              mode:
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                type: string
+                                                              resourceFieldRef:
+                                                                properties:
+                                                                  containerName:
+                                                                    type: string
+                                                                  divisor:
+                                                                    anyOf:
+                                                                    - type: integer
+                                                                    - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                  resource:
+                                                                    type: string
+                                                                required:
+                                                                - resource
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                            required:
+                                                            - path
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      type: object
+                                                    podCertificate:
+                                                      properties:
+                                                        certificateChainPath:
+                                                          type: string
+                                                        credentialBundlePath:
+                                                          type: string
+                                                        keyPath:
+                                                          type: string
+                                                        keyType:
+                                                          type: string
+                                                        maxExpirationSeconds:
+                                                          format: int32
+                                                          type: integer
+                                                        signerName:
+                                                          type: string
+                                                        userAnnotations:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      required:
+                                                      - keyType
+                                                      - signerName
+                                                      type: object
+                                                    secret:
+                                                      properties:
+                                                        items:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              mode:
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                type: string
+                                                            required:
+                                                            - key
+                                                            - path
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    serviceAccountToken:
+                                                      properties:
+                                                        audience:
+                                                          type: string
+                                                        expirationSeconds:
+                                                          format: int64
+                                                          type: integer
+                                                        path:
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          quobyte:
+                                            properties:
+                                              group:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              registry:
+                                                type: string
+                                              tenant:
+                                                type: string
+                                              user:
+                                                type: string
+                                              volume:
+                                                type: string
+                                            required:
+                                            - registry
+                                            - volume
+                                            type: object
+                                          rbd:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              image:
+                                                type: string
+                                              keyring:
+                                                default: /etc/ceph/keyring
+                                                type: string
+                                              monitors:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              pool:
+                                                default: rbd
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              user:
+                                                default: admin
+                                                type: string
+                                            required:
+                                            - image
+                                            - monitors
+                                            type: object
+                                          scaleIO:
+                                            properties:
+                                              fsType:
+                                                default: xfs
+                                                type: string
+                                              gateway:
+                                                type: string
+                                              protectionDomain:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              sslEnabled:
+                                                type: boolean
+                                              storageMode:
+                                                default: ThinProvisioned
+                                                type: string
+                                              storagePool:
+                                                type: string
+                                              system:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - gateway
+                                            - secretRef
+                                            - system
+                                            type: object
+                                          secret:
+                                            properties:
+                                              defaultMode:
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              optional:
+                                                type: boolean
+                                              secretName:
+                                                type: string
+                                            type: object
+                                          storageos:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    default: ""
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              volumeName:
+                                                type: string
+                                              volumeNamespace:
+                                                type: string
+                                            type: object
+                                          vsphereVolume:
+                                            properties:
+                                              fsType:
+                                                type: string
+                                              storagePolicyID:
+                                                type: string
+                                              storagePolicyName:
+                                                type: string
+                                              volumePath:
+                                                type: string
+                                            required:
+                                            - volumePath
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    workloadRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        podGroup:
+                                          type: string
+                                        podGroupReplicaKey:
+                                          type: string
+                                      required:
+                                      - name
+                                      - podGroup
+                                      type: object
+                                  required:
+                                  - containers
+                                  type: object
+                              type: object
+                          required:
+                          - groupName
+                          - maxReplicas
+                          - minReplicas
+                          - template
+                          type: object
+                        type: array
+                    required:
+                    - headGroupSpec
+                    type: object
+                  runtimeEnvYAML:
+                    type: string
+                  shutdownAfterJobFinishes:
+                    type: boolean
+                  submissionMode:
+                    default: K8sJobMode
+                    type: string
+                  submitterConfig:
+                    properties:
+                      backoffLimit:
+                        format: int32
+                        type: integer
+                    type: object
+                  submitterPodTemplate:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          activeDeadlineSeconds:
+                            format: int64
+                            type: integer
+                          affinity:
+                            properties:
+                              nodeAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        preference:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - preference
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    properties:
+                                      nodeSelectorTerms:
+                                        items:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - nodeSelectorTerms
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              podAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              podAntiAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                            type: object
+                          automountServiceAccountToken:
+                            type: boolean
+                          containers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          dnsConfig:
+                            properties:
+                              nameservers:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              options:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              searches:
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          dnsPolicy:
+                            type: string
+                          enableServiceLinks:
+                            type: boolean
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                targetContainerName:
+                                  type: string
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          hostAliases:
+                            items:
+                              properties:
+                                hostnames:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                ip:
+                                  type: string
+                              required:
+                              - ip
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - ip
+                            x-kubernetes-list-type: map
+                          hostIPC:
+                            type: boolean
+                          hostNetwork:
+                            type: boolean
+                          hostPID:
+                            type: boolean
+                          hostUsers:
+                            type: boolean
+                          hostname:
+                            type: string
+                          hostnameOverride:
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          initContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              optional:
+                                                default: false
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              volumeName:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            default: ""
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                restartPolicyRules:
+                                  items:
+                                    properties:
+                                      action:
+                                        type: string
+                                      exitCodes:
+                                        properties:
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        type: object
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          nodeName:
+                            type: string
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          os:
+                            properties:
+                              name:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          overhead:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          preemptionPolicy:
+                            type: string
+                          priority:
+                            format: int32
+                            type: integer
+                          priorityClassName:
+                            type: string
+                          readinessGates:
+                            items:
+                              properties:
+                                conditionType:
+                                  type: string
+                              required:
+                              - conditionType
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          resourceClaims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                resourceClaimName:
+                                  type: string
+                                resourceClaimTemplateName:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    request:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          restartPolicy:
+                            type: string
+                          runtimeClassName:
+                            type: string
+                          schedulerName:
+                            type: string
+                          schedulingGates:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          securityContext:
+                            properties:
+                              appArmorProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              fsGroup:
+                                format: int64
+                                type: integer
+                              fsGroupChangePolicy:
+                                type: string
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                              seLinuxChangePolicy:
+                                type: string
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              supplementalGroups:
+                                items:
+                                  format: int64
+                                  type: integer
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              supplementalGroupsPolicy:
+                                type: string
+                              sysctls:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  hostProcess:
+                                    type: boolean
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          serviceAccount:
+                            type: string
+                          serviceAccountName:
+                            type: string
+                          setHostnameAsFQDN:
+                            type: boolean
+                          shareProcessNamespace:
+                            type: boolean
+                          subdomain:
+                            type: string
+                          terminationGracePeriodSeconds:
+                            format: int64
+                            type: integer
+                          tolerations:
+                            items:
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  format: int64
+                                  type: integer
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                maxSkew:
+                                  format: int32
+                                  type: integer
+                                minDomains:
+                                  format: int32
+                                  type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - topologyKey
+                            - whenUnsatisfiable
+                            x-kubernetes-list-type: map
+                          volumes:
+                            items:
+                              properties:
+                                awsElasticBlockStore:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                azureDisk:
+                                  properties:
+                                    cachingMode:
+                                      type: string
+                                    diskName:
+                                      type: string
+                                    diskURI:
+                                      type: string
+                                    fsType:
+                                      default: ext4
+                                      type: string
+                                    kind:
+                                      type: string
+                                    readOnly:
+                                      default: false
+                                      type: boolean
+                                  required:
+                                  - diskName
+                                  - diskURI
+                                  type: object
+                                azureFile:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                    shareName:
+                                      type: string
+                                  required:
+                                  - secretName
+                                  - shareName
+                                  type: object
+                                cephfs:
+                                  properties:
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretFile:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      type: string
+                                  required:
+                                  - monitors
+                                  type: object
+                                cinder:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                configMap:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                csi:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  required:
+                                  - driver
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                emptyDir:
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  properties:
+                                    volumeClaimTemplate:
+                                      properties:
+                                        metadata:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                          type: object
+                                        spec:
+                                          properties:
+                                            accessModes:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            dataSource:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            dataSourceRef:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                            resources:
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            storageClassName:
+                                              type: string
+                                            volumeAttributesClassName:
+                                              type: string
+                                            volumeMode:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          type: object
+                                      required:
+                                      - spec
+                                      type: object
+                                  type: object
+                                fc:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    lun:
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    targetWWNs:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    wwids:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                flexVolume:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - driver
+                                  type: object
+                                flocker:
+                                  properties:
+                                    datasetName:
+                                      type: string
+                                    datasetUUID:
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      format: int32
+                                      type: integer
+                                    pdName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - pdName
+                                  type: object
+                                gitRepo:
+                                  properties:
+                                    directory:
+                                      type: string
+                                    repository:
+                                      type: string
+                                    revision:
+                                      type: string
+                                  required:
+                                  - repository
+                                  type: object
+                                glusterfs:
+                                  properties:
+                                    endpoints:
+                                      type: string
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - endpoints
+                                  - path
+                                  type: object
+                                hostPath:
+                                  properties:
+                                    path:
+                                      type: string
+                                    type:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                image:
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  type: object
+                                iscsi:
+                                  properties:
+                                    chapAuthDiscovery:
+                                      type: boolean
+                                    chapAuthSession:
+                                      type: boolean
+                                    fsType:
+                                      type: string
+                                    initiatorName:
+                                      type: string
+                                    iqn:
+                                      type: string
+                                    iscsiInterface:
+                                      default: default
+                                      type: string
+                                    lun:
+                                      format: int32
+                                      type: integer
+                                    portals:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    targetPortal:
+                                      type: string
+                                  required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                  type: object
+                                name:
+                                  type: string
+                                nfs:
+                                  properties:
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    server:
+                                      type: string
+                                  required:
+                                  - path
+                                  - server
+                                  type: object
+                                persistentVolumeClaim:
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  required:
+                                  - claimName
+                                  type: object
+                                photonPersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    pdID:
+                                      type: string
+                                  required:
+                                  - pdID
+                                  type: object
+                                portworxVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                projected:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    sources:
+                                      items:
+                                        properties:
+                                          clusterTrustBundle:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              signerName:
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                          configMap:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          downwardAPI:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          podCertificate:
+                                            properties:
+                                              certificateChainPath:
+                                                type: string
+                                              credentialBundlePath:
+                                                type: string
+                                              keyPath:
+                                                type: string
+                                              keyType:
+                                                type: string
+                                              maxExpirationSeconds:
+                                                format: int32
+                                                type: integer
+                                              signerName:
+                                                type: string
+                                              userAnnotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            required:
+                                            - keyType
+                                            - signerName
+                                            type: object
+                                          secret:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          serviceAccountToken:
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                format: int64
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                quobyte:
+                                  properties:
+                                    group:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    registry:
+                                      type: string
+                                    tenant:
+                                      type: string
+                                    user:
+                                      type: string
+                                    volume:
+                                      type: string
+                                  required:
+                                  - registry
+                                  - volume
+                                  type: object
+                                rbd:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    image:
+                                      type: string
+                                    keyring:
+                                      default: /etc/ceph/keyring
+                                      type: string
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    pool:
+                                      default: rbd
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      default: admin
+                                      type: string
+                                  required:
+                                  - image
+                                  - monitors
+                                  type: object
+                                scaleIO:
+                                  properties:
+                                    fsType:
+                                      default: xfs
+                                      type: string
+                                    gateway:
+                                      type: string
+                                    protectionDomain:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    sslEnabled:
+                                      type: boolean
+                                    storageMode:
+                                      default: ThinProvisioned
+                                      type: string
+                                    storagePool:
+                                      type: string
+                                    system:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                  type: object
+                                secret:
+                                  properties:
+                                    defaultMode:
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  type: object
+                                storageos:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          default: ""
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeName:
+                                      type: string
+                                    volumeNamespace:
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    storagePolicyID:
+                                      type: string
+                                    storagePolicyName:
+                                      type: string
+                                    volumePath:
+                                      type: string
+                                  required:
+                                  - volumePath
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          workloadRef:
+                            properties:
+                              name:
+                                type: string
+                              podGroup:
+                                type: string
+                              podGroupReplicaKey:
+                                type: string
+                            required:
+                            - name
+                            - podGroup
+                            type: object
+                        required:
+                        - containers
+                        type: object
+                    type: object
+                  suspend:
+                    type: boolean
+                  ttlSecondsAfterFinished:
+                    default: 0
+                    format: int32
+                    type: integer
+                type: object
+              schedule:
+                type: string
+              suspend:
+                type: boolean
+            required:
+            - jobTemplate
+            - schedule
+            type: object
+          status:
+            properties:
+              lastScheduleTime:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayjobs.yaml
@@ -58,12 +58,77 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
-              deletionPolicy:
-                type: string
+              deletionStrategy:
+                properties:
+                  deletionRules:
+                    items:
+                      properties:
+                        condition:
+                          properties:
+                            jobDeploymentStatus:
+                              enum:
+                              - Failed
+                              type: string
+                            jobStatus:
+                              enum:
+                              - SUCCEEDED
+                              - FAILED
+                              type: string
+                            ttlSeconds:
+                              default: 0
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          type: object
+                          x-kubernetes-validations:
+                          - message: JobStatus and JobDeploymentStatus cannot be used
+                              together within the same deletion condition.
+                            rule: '!(has(self.jobStatus) && has(self.jobDeploymentStatus))'
+                          - message: the deletion condition requires either the JobStatus
+                              or the JobDeploymentStatus field.
+                            rule: has(self.jobStatus) || has(self.jobDeploymentStatus)
+                        policy:
+                          enum:
+                          - DeleteCluster
+                          - DeleteWorkers
+                          - DeleteSelf
+                          - DeleteNone
+                          type: string
+                      required:
+                      - condition
+                      - policy
+                      type: object
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  onFailure:
+                    properties:
+                      policy:
+                        enum:
+                        - DeleteCluster
+                        - DeleteWorkers
+                        - DeleteSelf
+                        - DeleteNone
+                        type: string
+                    type: object
+                  onSuccess:
+                    properties:
+                      policy:
+                        enum:
+                        - DeleteCluster
+                        - DeleteWorkers
+                        - DeleteSelf
+                        - DeleteNone
+                        type: string
+                    type: object
+                type: object
                 x-kubernetes-validations:
-                - message: the deletionPolicy field value must be either 'DeleteCluster',
-                    'DeleteWorkers', 'DeleteSelf', or 'DeleteNone'
-                  rule: self in ['DeleteCluster', 'DeleteWorkers', 'DeleteSelf', 'DeleteNone']
+                - message: legacy policies (onSuccess/onFailure) and deletionRules
+                    cannot be used together within the same deletionStrategy
+                  rule: '!((has(self.onSuccess) || has(self.onFailure)) && has(self.deletionRules))'
+                - message: deletionStrategy requires either BOTH onSuccess and onFailure,
+                    OR the deletionRules field (cannot be empty)
+                  rule: ((has(self.onSuccess) && has(self.onFailure)) || has(self.deletionRules))
               entrypoint:
                 type: string
               entrypointNumCpus:
@@ -86,8 +151,24 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
+              preRunningDeadlineSeconds:
+                format: int32
+                minimum: 1
+                type: integer
               rayClusterSpec:
                 properties:
+                  authOptions:
+                    properties:
+                      enableK8sTokenAuth:
+                        type: boolean
+                      mode:
+                        enum:
+                        - disabled
+                        - token
+                        type: string
+                      secretName:
+                        type: string
+                    type: object
                   autoscalerOptions:
                     properties:
                       env:
@@ -120,6 +201,23 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -364,6 +462,23 @@ spec:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
                               resourceFieldRef:
                                 properties:
                                   containerName:
@@ -422,6 +537,23 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -657,7 +789,15 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       rayStartParams:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      resources:
                         additionalProperties:
                           type: string
                         type: object
@@ -1175,6 +1315,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -1603,6 +1760,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -1887,6 +2067,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -2315,6 +2512,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -2556,6 +2776,8 @@ spec:
                                 type: boolean
                               hostname:
                                 type: string
+                              hostnameOverride:
+                                type: string
                               imagePullSecrets:
                                 items:
                                   properties:
@@ -2611,6 +2833,23 @@ spec:
                                                     type: string
                                                 required:
                                                 - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
@@ -3041,6 +3280,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -4137,6 +4399,29 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 type: object
+                                              podCertificate:
+                                                properties:
+                                                  certificateChainPath:
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    type: string
+                                                  keyPath:
+                                                    type: string
+                                                  keyType:
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
                                               secret:
                                                 properties:
                                                   items:
@@ -4327,6 +4612,18 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 - name
                                 x-kubernetes-list-type: map
+                              workloadRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  podGroup:
+                                    type: string
+                                  podGroupReplicaKey:
+                                    type: string
+                                required:
+                                - name
+                                - podGroup
+                                type: object
                             required:
                             - containers
                             type: object
@@ -4350,6 +4647,14 @@ spec:
                     type: string
                   suspend:
                     type: boolean
+                  upgradeStrategy:
+                    properties:
+                      type:
+                        enum:
+                        - Recreate
+                        - None
+                        type: string
+                    type: object
                   workerGroupSpecs:
                     items:
                       properties:
@@ -4358,6 +4663,10 @@ spec:
                         idleTimeoutSeconds:
                           format: int32
                           type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
                         maxReplicas:
                           default: 2147483647
                           format: int32
@@ -4378,6 +4687,10 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        resources:
+                          additionalProperties:
+                            type: string
+                          type: object
                         scaleStrategy:
                           properties:
                             workersToDelete:
@@ -4899,6 +5212,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -5327,6 +5657,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -5611,6 +5964,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -6039,6 +6409,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -6280,6 +6673,8 @@ spec:
                                   type: boolean
                                 hostname:
                                   type: string
+                                hostnameOverride:
+                                  type: string
                                 imagePullSecrets:
                                   items:
                                     properties:
@@ -6335,6 +6730,23 @@ spec:
                                                       type: string
                                                   required:
                                                   - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
@@ -6765,6 +7177,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -7861,6 +8296,29 @@ spec:
                                                       type: array
                                                       x-kubernetes-list-type: atomic
                                                   type: object
+                                                podCertificate:
+                                                  properties:
+                                                    certificateChainPath:
+                                                      type: string
+                                                    credentialBundlePath:
+                                                      type: string
+                                                    keyPath:
+                                                      type: string
+                                                    keyType:
+                                                      type: string
+                                                    maxExpirationSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    signerName:
+                                                      type: string
+                                                    userAnnotations:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  required:
+                                                  - keyType
+                                                  - signerName
+                                                  type: object
                                                 secret:
                                                   properties:
                                                     items:
@@ -8051,6 +8509,18 @@ spec:
                                   x-kubernetes-list-map-keys:
                                   - name
                                   x-kubernetes-list-type: map
+                                workloadRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    podGroup:
+                                      type: string
+                                    podGroupReplicaKey:
+                                      type: string
+                                  required:
+                                  - name
+                                  - podGroup
+                                  type: object
                               required:
                               - containers
                               type: object
@@ -8590,6 +9060,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -9018,6 +9505,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -9302,6 +9812,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -9730,6 +10257,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -9971,6 +10521,8 @@ spec:
                         type: boolean
                       hostname:
                         type: string
+                      hostnameOverride:
+                        type: string
                       imagePullSecrets:
                         items:
                           properties:
@@ -10026,6 +10578,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -10456,6 +11025,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -11552,6 +12144,29 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         properties:
                                           items:
@@ -11742,6 +12357,18 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      workloadRef:
+                        properties:
+                          name:
+                            type: string
+                          podGroup:
+                            type: string
+                          podGroupReplicaKey:
+                            type: string
+                        required:
+                        - name
+                        - podGroup
+                        type: object
                     required:
                     - containers
                     type: object
@@ -11977,6 +12604,23 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -12898,6 +13542,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -13326,6 +13987,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -13610,6 +14294,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -14038,6 +14739,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -14279,6 +15003,8 @@ spec:
                                 type: boolean
                               hostname:
                                 type: string
+                              hostnameOverride:
+                                type: string
                               imagePullSecrets:
                                 items:
                                   properties:
@@ -14334,6 +15060,23 @@ spec:
                                                     type: string
                                                 required:
                                                 - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
@@ -14764,6 +15507,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -15860,6 +16626,29 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 type: object
+                                              podCertificate:
+                                                properties:
+                                                  certificateChainPath:
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    type: string
+                                                  keyPath:
+                                                    type: string
+                                                  keyType:
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
                                               secret:
                                                 properties:
                                                   items:
@@ -16050,6 +16839,18 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 - name
                                 x-kubernetes-list-type: map
+                              workloadRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  podGroup:
+                                    type: string
+                                  podGroupReplicaKey:
+                                    type: string
+                                required:
+                                - name
+                                - podGroup
+                                type: object
                             required:
                             - containers
                             type: object
@@ -16606,6 +17407,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -17034,6 +17852,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -17318,6 +18159,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -17746,6 +18604,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -17987,6 +18868,8 @@ spec:
                                   type: boolean
                                 hostname:
                                   type: string
+                                hostnameOverride:
+                                  type: string
                                 imagePullSecrets:
                                   items:
                                     properties:
@@ -18042,6 +18925,23 @@ spec:
                                                       type: string
                                                   required:
                                                   - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
@@ -18472,6 +19372,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -19568,6 +20491,29 @@ spec:
                                                       type: array
                                                       x-kubernetes-list-type: atomic
                                                   type: object
+                                                podCertificate:
+                                                  properties:
+                                                    certificateChainPath:
+                                                      type: string
+                                                    credentialBundlePath:
+                                                      type: string
+                                                    keyPath:
+                                                      type: string
+                                                    keyType:
+                                                      type: string
+                                                    maxExpirationSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    signerName:
+                                                      type: string
+                                                    userAnnotations:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  required:
+                                                  - keyType
+                                                  - signerName
+                                                  type: object
                                                 secret:
                                                   properties:
                                                     items:
@@ -19758,6 +20704,18 @@ spec:
                                   x-kubernetes-list-map-keys:
                                   - name
                                   x-kubernetes-list-type: map
+                                workloadRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    podGroup:
+                                      type: string
+                                    podGroupReplicaKey:
+                                      type: string
+                                  required:
+                                  - name
+                                  - podGroup
+                                  type: object
                               required:
                               - containers
                               type: object
@@ -20289,6 +21247,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -20717,6 +21692,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -21001,6 +21999,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -21429,6 +22444,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -21670,6 +22708,8 @@ spec:
                         type: boolean
                       hostname:
                         type: string
+                      hostnameOverride:
+                        type: string
                       imagePullSecrets:
                         items:
                           properties:
@@ -21725,6 +22765,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -22155,6 +23212,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -23251,6 +24331,29 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         properties:
                                           items:
@@ -23441,6 +24544,18 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      workloadRef:
+                        properties:
+                          name:
+                            type: string
+                          podGroup:
+                            type: string
+                          podGroupReplicaKey:
+                            type: string
+                        required:
+                        - name
+                        - podGroup
+                        type: object
                     required:
                     - containers
                     type: object

--- a/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
+++ b/helm-chart/kuberay-operator/crds/ray.io_rayservices.yaml
@@ -40,8 +40,28 @@ spec:
                 type: integer
               excludeHeadPodFromServeSvc:
                 type: boolean
+              managedBy:
+                type: string
+                x-kubernetes-validations:
+                - message: the managedBy field is immutable
+                  rule: self == oldSelf
+                - message: the managedBy field value must be either 'ray.io/kuberay-operator'
+                    or 'kueue.x-k8s.io/multikueue'
+                  rule: self in ['ray.io/kuberay-operator', 'kueue.x-k8s.io/multikueue']
               rayClusterConfig:
                 properties:
+                  authOptions:
+                    properties:
+                      enableK8sTokenAuth:
+                        type: boolean
+                      mode:
+                        enum:
+                        - disabled
+                        - token
+                        type: string
+                      secretName:
+                        type: string
+                    type: object
                   autoscalerOptions:
                     properties:
                       env:
@@ -74,6 +94,23 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -318,6 +355,23 @@ spec:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
                               resourceFieldRef:
                                 properties:
                                   containerName:
@@ -376,6 +430,23 @@ spec:
                                     type: string
                                 required:
                                 - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -611,7 +682,15 @@ spec:
                                 type: object
                             type: object
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       rayStartParams:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      resources:
                         additionalProperties:
                           type: string
                         type: object
@@ -1129,6 +1208,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -1557,6 +1653,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -1841,6 +1960,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -2269,6 +2405,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -2510,6 +2669,8 @@ spec:
                                 type: boolean
                               hostname:
                                 type: string
+                              hostnameOverride:
+                                type: string
                               imagePullSecrets:
                                 items:
                                   properties:
@@ -2565,6 +2726,23 @@ spec:
                                                     type: string
                                                 required:
                                                 - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
@@ -2995,6 +3173,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -4091,6 +4292,29 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 type: object
+                                              podCertificate:
+                                                properties:
+                                                  certificateChainPath:
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    type: string
+                                                  keyPath:
+                                                    type: string
+                                                  keyType:
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
                                               secret:
                                                 properties:
                                                   items:
@@ -4281,6 +4505,18 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 - name
                                 x-kubernetes-list-type: map
+                              workloadRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  podGroup:
+                                    type: string
+                                  podGroupReplicaKey:
+                                    type: string
+                                required:
+                                - name
+                                - podGroup
+                                type: object
                             required:
                             - containers
                             type: object
@@ -4304,6 +4540,14 @@ spec:
                     type: string
                   suspend:
                     type: boolean
+                  upgradeStrategy:
+                    properties:
+                      type:
+                        enum:
+                        - Recreate
+                        - None
+                        type: string
+                    type: object
                   workerGroupSpecs:
                     items:
                       properties:
@@ -4312,6 +4556,10 @@ spec:
                         idleTimeoutSeconds:
                           format: int32
                           type: integer
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
                         maxReplicas:
                           default: 2147483647
                           format: int32
@@ -4332,6 +4580,10 @@ spec:
                           default: 0
                           format: int32
                           type: integer
+                        resources:
+                          additionalProperties:
+                            type: string
+                          type: object
                         scaleStrategy:
                           properties:
                             workersToDelete:
@@ -4853,6 +5105,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -5281,6 +5550,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -5565,6 +5857,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -5993,6 +6302,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -6234,6 +6566,8 @@ spec:
                                   type: boolean
                                 hostname:
                                   type: string
+                                hostnameOverride:
+                                  type: string
                                 imagePullSecrets:
                                   items:
                                     properties:
@@ -6289,6 +6623,23 @@ spec:
                                                       type: string
                                                   required:
                                                   - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
@@ -6719,6 +7070,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -7815,6 +8189,29 @@ spec:
                                                       type: array
                                                       x-kubernetes-list-type: atomic
                                                   type: object
+                                                podCertificate:
+                                                  properties:
+                                                    certificateChainPath:
+                                                      type: string
+                                                    credentialBundlePath:
+                                                      type: string
+                                                    keyPath:
+                                                      type: string
+                                                    keyType:
+                                                      type: string
+                                                    maxExpirationSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    signerName:
+                                                      type: string
+                                                    userAnnotations:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  required:
+                                                  - keyType
+                                                  - signerName
+                                                  type: object
                                                 secret:
                                                   properties:
                                                     items:
@@ -8005,6 +8402,18 @@ spec:
                                   x-kubernetes-list-map-keys:
                                   - name
                                   x-kubernetes-list-type: map
+                                workloadRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    podGroup:
+                                      type: string
+                                    podGroupReplicaKey:
+                                      type: string
+                                  required:
+                                  - name
+                                  - podGroup
+                                  type: object
                               required:
                               - containers
                               type: object
@@ -8019,6 +8428,10 @@ spec:
                 required:
                 - headGroupSpec
                 type: object
+              rayClusterDeletionDelaySeconds:
+                format: int32
+                minimum: 0
+                type: integer
               serveConfigV2:
                 type: string
               serveService:
@@ -8221,6 +8634,25 @@ spec:
                 type: integer
               upgradeStrategy:
                 properties:
+                  clusterUpgradeOptions:
+                    properties:
+                      gatewayClassName:
+                        type: string
+                      intervalSeconds:
+                        format: int32
+                        type: integer
+                      maxSurgePercent:
+                        default: 100
+                        format: int32
+                        type: integer
+                      stepSizePercent:
+                        format: int32
+                        type: integer
+                    required:
+                    - gatewayClassName
+                    - intervalSeconds
+                    - stepSizePercent
+                    type: object
                   type:
                     type: string
                 type: object
@@ -8249,6 +8681,9 @@ spec:
                           type: string
                       type: object
                     type: object
+                  lastTrafficMigratedTime:
+                    format: date-time
+                    type: string
                   rayClusterName:
                     type: string
                   rayClusterStatus:
@@ -8363,6 +8798,12 @@ spec:
                           type: string
                         type: object
                     type: object
+                  targetCapacity:
+                    format: int32
+                    type: integer
+                  trafficRoutedPercent:
+                    format: int32
+                    type: integer
                 type: object
               conditions:
                 items:
@@ -8432,6 +8873,9 @@ spec:
                           type: string
                       type: object
                     type: object
+                  lastTrafficMigratedTime:
+                    format: date-time
+                    type: string
                   rayClusterName:
                     type: string
                   rayClusterStatus:
@@ -8546,6 +8990,12 @@ spec:
                           type: string
                         type: object
                     type: object
+                  targetCapacity:
+                    format: int32
+                    type: integer
+                  trafficRoutedPercent:
+                    format: int32
+                    type: integer
                 type: object
               serviceStatus:
                 type: string
@@ -8604,6 +9054,23 @@ spec:
                                       type: string
                                   required:
                                   - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -9525,6 +9992,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -9953,6 +10437,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -10237,6 +10744,23 @@ spec:
                                                 - fieldPath
                                                 type: object
                                                 x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
                                               resourceFieldRef:
                                                 properties:
                                                   containerName:
@@ -10665,6 +11189,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -10906,6 +11453,8 @@ spec:
                                 type: boolean
                               hostname:
                                 type: string
+                              hostnameOverride:
+                                type: string
                               imagePullSecrets:
                                 items:
                                   properties:
@@ -10961,6 +11510,23 @@ spec:
                                                     type: string
                                                 required:
                                                 - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    type: boolean
+                                                  path:
+                                                    type: string
+                                                  volumeName:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
                                                 type: object
                                                 x-kubernetes-map-type: atomic
                                               resourceFieldRef:
@@ -11391,6 +11957,29 @@ spec:
                                       type: object
                                     restartPolicy:
                                       type: string
+                                    restartPolicyRules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          exitCodes:
+                                            properties:
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
                                     securityContext:
                                       properties:
                                         allowPrivilegeEscalation:
@@ -12487,6 +13076,29 @@ spec:
                                                     type: array
                                                     x-kubernetes-list-type: atomic
                                                 type: object
+                                              podCertificate:
+                                                properties:
+                                                  certificateChainPath:
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    type: string
+                                                  keyPath:
+                                                    type: string
+                                                  keyType:
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
                                               secret:
                                                 properties:
                                                   items:
@@ -12677,6 +13289,18 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 - name
                                 x-kubernetes-list-type: map
+                              workloadRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  podGroup:
+                                    type: string
+                                  podGroupReplicaKey:
+                                    type: string
+                                required:
+                                - name
+                                - podGroup
+                                type: object
                             required:
                             - containers
                             type: object
@@ -13233,6 +13857,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -13661,6 +14302,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -13945,6 +14609,23 @@ spec:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
                                                   properties:
                                                     containerName:
@@ -14373,6 +15054,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -14614,6 +15318,8 @@ spec:
                                   type: boolean
                                 hostname:
                                   type: string
+                                hostnameOverride:
+                                  type: string
                                 imagePullSecrets:
                                   items:
                                     properties:
@@ -14669,6 +15375,23 @@ spec:
                                                       type: string
                                                   required:
                                                   - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      type: boolean
+                                                    path:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  - volumeName
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 resourceFieldRef:
@@ -15099,6 +15822,29 @@ spec:
                                         type: object
                                       restartPolicy:
                                         type: string
+                                      restartPolicyRules:
+                                        items:
+                                          properties:
+                                            action:
+                                              type: string
+                                            exitCodes:
+                                              properties:
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                              - operator
+                                              type: object
+                                          required:
+                                          - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                       securityContext:
                                         properties:
                                           allowPrivilegeEscalation:
@@ -16195,6 +16941,29 @@ spec:
                                                       type: array
                                                       x-kubernetes-list-type: atomic
                                                   type: object
+                                                podCertificate:
+                                                  properties:
+                                                    certificateChainPath:
+                                                      type: string
+                                                    credentialBundlePath:
+                                                      type: string
+                                                    keyPath:
+                                                      type: string
+                                                    keyType:
+                                                      type: string
+                                                    maxExpirationSeconds:
+                                                      format: int32
+                                                      type: integer
+                                                    signerName:
+                                                      type: string
+                                                    userAnnotations:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  required:
+                                                  - keyType
+                                                  - signerName
+                                                  type: object
                                                 secret:
                                                   properties:
                                                     items:
@@ -16385,6 +17154,18 @@ spec:
                                   x-kubernetes-list-map-keys:
                                   - name
                                   x-kubernetes-list-type: map
+                                workloadRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    podGroup:
+                                      type: string
+                                    podGroupReplicaKey:
+                                      type: string
+                                  required:
+                                  - name
+                                  - podGroup
+                                  type: object
                               required:
                               - containers
                               type: object

--- a/helm-chart/kuberay-operator/templates/_helpers.tpl
+++ b/helm-chart/kuberay-operator/templates/_helpers.tpl
@@ -104,6 +104,34 @@ FeatureGates
 {{- include "kuberay-operator.fullname" . -}}
 {{- end -}}
 
+{{/*
+Validate operator configuration values.
+This template validates reconcileConcurrency, kubeClient.qps, and kubeClient.burst.
+It should be called early in the deployment to ensure invalid values are caught.
+*/}}
+{{- define "kuberay-operator.validateConfig" -}}
+{{- if hasKey .Values "reconcileConcurrency" }}
+{{- $rc := toString .Values.reconcileConcurrency }}
+{{- if not (regexMatch "^[1-9][0-9]*$" $rc) }}
+{{- fail (printf "values.reconcileConcurrency must be a positive integer, got %q" $rc) }}
+{{- end }}
+{{- end }}
+{{- if hasKey .Values "kubeClient" }}
+{{- if hasKey .Values.kubeClient "qps" }}
+{{- $qps := toString .Values.kubeClient.qps }}
+{{- if not (regexMatch "^[0-9]+(\\.[0-9]+)?$" $qps) }}
+{{- fail (printf "values.kubeClient.qps must be a valid float number, got %q" $qps) }}
+{{- end }}
+{{- end }}
+{{- if hasKey .Values.kubeClient "burst" }}
+{{- $burst := toString .Values.kubeClient.burst }}
+{{- if not (regexMatch "^[0-9]+$" $burst) }}
+{{- fail (printf "values.kubeClient.burst must be a non-negative integer, got %q" $burst) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- /* Create the name of the leader election role to use. */ -}}
 {{- define "kuberay-operator.leaderElectionRole.name" -}}
 {{- include "kuberay-operator.fullname" . -}}-leader-election
@@ -119,14 +147,6 @@ Create a template to ensure consistency for Role and ClusterRole.
 */}}
 {{- define "role.consistentRules" -}}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -163,6 +183,21 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/resize
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -204,6 +239,14 @@ rules:
   - list
   - update
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   - networking.k8s.io
   resources:
@@ -214,6 +257,17 @@ rules:
   - get
   - list
   - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  - httproutes
+  verbs:
+  - create
+  - get
+  - list
   - update
   - watch
 - apiGroups:
@@ -228,6 +282,7 @@ rules:
   - ray.io
   resources:
   - rayclusters
+  - raycronjobs
   - rayjobs
   - rayservices
   verbs:
@@ -242,6 +297,7 @@ rules:
   - ray.io
   resources:
   - rayclusters/finalizers
+  - raycronjobs/finalizers
   - rayjobs/finalizers
   - rayservices/finalizers
   verbs:
@@ -250,6 +306,7 @@ rules:
   - ray.io
   resources:
   - rayclusters/status
+  - raycronjobs/status
   - rayjobs/status
   - rayservices/status
   verbs:
@@ -301,12 +358,6 @@ rules:
   - list
   - update
   - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
 {{- end -}}
 {{- if or .batchSchedulerEnabled (eq .batchSchedulerName "scheduler-plugins") }}
 - apiGroups:

--- a/helm-chart/kuberay-operator/templates/configmap.yaml
+++ b/helm-chart/kuberay-operator/templates/configmap.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.configuration.enabled }}
+{{- include "kuberay-operator.validateConfig" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kuberay-operator.deployment.name" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  config.yaml: |
+    apiVersion: config.ray.io/v1alpha1
+    kind: Configuration
+    {{- if hasKey .Values "leaderElectionEnabled" }}
+    enableLeaderElection: {{ .Values.leaderElectionEnabled }}
+    {{- end }}
+    {{- if and (hasKey .Values "metrics") (hasKey .Values.metrics "enabled") }}
+    enableMetrics: {{ .Values.metrics.enabled }}
+    {{- end }}
+    {{- if hasKey .Values "reconcileConcurrency" }}
+    reconcileConcurrency: {{ .Values.reconcileConcurrency }}
+    {{- end }}
+    {{- if hasKey .Values "useKubernetesProxy" }}
+    useKubernetesProxy: {{ .Values.useKubernetesProxy }}
+    {{- end }}
+    {{- if hasKey .Values "kubeClient" }}
+    {{- if hasKey .Values.kubeClient "qps" }}
+    qps: {{ .Values.kubeClient.qps }}
+    {{- end }}
+    {{- if hasKey .Values.kubeClient "burst" }}
+    burst: {{ .Values.kubeClient.burst }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.watchNamespace }}
+    watchNamespace: {{ join "," .Values.watchNamespace | quote }}
+    {{- else if .Values.singleNamespaceInstall }}
+    watchNamespace: {{ .Release.Namespace | quote }}
+    {{- end }}
+    {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
+    logFile: {{ printf "%s/%s" .Values.logging.baseDir .Values.logging.fileName | quote }}
+    {{- end }}
+    {{- if .Values.logging.stdoutEncoder }}
+    logStdoutEncoder: {{ .Values.logging.stdoutEncoder | quote }}
+    {{- end }}
+    {{- if .Values.logging.fileEncoder }}
+    logFileEncoder: {{ .Values.logging.fileEncoder | quote }}
+    {{- end }}
+    {{- if .Values.batchScheduler }}
+    {{- if .Values.batchScheduler.enabled }}
+    enableBatchScheduler: true
+    {{- end }}
+    {{- if .Values.batchScheduler.name }}
+    batchScheduler: {{ .Values.batchScheduler.name | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.configuration.headSidecarContainers }}
+    headSidecarContainers:
+    {{- toYaml .Values.configuration.headSidecarContainers | nindent 4 }}
+    {{- end }}
+    {{- if .Values.configuration.workerSidecarContainers }}
+    workerSidecarContainers:
+    {{- toYaml .Values.configuration.workerSidecarContainers | nindent 4 }}
+    {{- end }}
+    {{- if .Values.configuration.defaultContainerEnvs }}
+    defaultContainerEnvs:
+    {{- toYaml .Values.configuration.defaultContainerEnvs | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/deployment.yaml
+++ b/helm-chart/kuberay-operator/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas | default 1 }}
   strategy:
     type: Recreate
   selector:
@@ -35,8 +35,9 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "kuberay-operator.serviceAccount.name" . }}
-      {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
+      {{- if or (and (.Values.logging.baseDir) (.Values.logging.fileName)) .Values.configuration.enabled }}
       volumes:
+      {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
         - name: kuberay-logs
           {{- if .Values.logging.sizeLimit }}
           emptyDir:
@@ -45,9 +46,18 @@ spec:
           emptyDir: {}
           {{- end }}
       {{- end }}
+      {{- if .Values.configuration.enabled }}
+        - name: operator-config
+          configMap:
+            name: {{ include "kuberay-operator.deployment.name" . }}-config
+      {{- end }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -59,16 +69,27 @@ spec:
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
-          {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
+          {{- if or (and (.Values.logging.baseDir) (.Values.logging.fileName)) .Values.configuration.enabled }}
           volumeMounts:
+          {{- if and (.Values.logging.baseDir) (.Values.logging.fileName) }}
             - name: kuberay-logs
               mountPath: "{{ .Values.logging.baseDir }}"
+          {{- end }}
+          {{- if .Values.configuration.enabled }}
+            - name: operator-config
+              mountPath: /etc/kuberay
+              readOnly: true
+          {{- end }}
           {{- end }}
           command:
             - {{ .Values.operatorCommand }}
           args:
             {{- $argList := list -}}
-            {{- $argList = append $argList (include "kuberay.featureGates" . | trim) -}}
+            {{- if .Values.configuration.enabled -}}
+            {{- $argList = append $argList "--config" -}}
+            {{- $argList = append $argList "/etc/kuberay/config.yaml" -}}
+            {{- else -}}
+            {{- include "kuberay-operator.validateConfig" . -}}
             {{- if .Values.batchScheduler -}}
             {{- if .Values.batchScheduler.enabled -}}
             {{- $argList = append $argList "--enable-batch-scheduler" -}}
@@ -108,6 +129,19 @@ spec:
             {{- if and (hasKey .Values "metrics") (hasKey .Values.metrics "enabled") }}
             {{- $argList = append $argList (printf "--enable-metrics=%t" .Values.metrics.enabled) -}}
             {{- end -}}
+            {{- if hasKey .Values "reconcileConcurrency" -}}
+            {{- $argList = append $argList (printf "--reconcile-concurrency=%v" .Values.reconcileConcurrency) -}}
+            {{- end -}}
+            {{- if hasKey .Values "kubeClient" -}}
+            {{- if hasKey .Values.kubeClient "qps" -}}
+            {{- $argList = append $argList (printf "--qps=%v" .Values.kubeClient.qps) -}}
+            {{- end -}}
+            {{- if hasKey .Values.kubeClient "burst" -}}
+            {{- $argList = append $argList (printf "--burst=%v" .Values.kubeClient.burst) -}}
+            {{- end -}}
+            {{- end -}}
+            {{- end -}}
+            {{- $argList = append $argList (include "kuberay.featureGates" . | trim) -}}
             {{- (printf "\n") -}}
             {{- $argList | toYaml | indent 12 }}
           ports:

--- a/helm-chart/kuberay-operator/templates/ray_raycronjob_editor_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_raycronjob_editor_role.yaml
@@ -1,0 +1,28 @@
+{{- /* ClusterRole for end users to view and edit RayCronJob. */ -}}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: raycronjob-editor-role
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - raycronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - raycronjobs/status
+  verbs:
+  - get
+{{- end }}

--- a/helm-chart/kuberay-operator/templates/ray_raycronjob_viewer_role.yaml
+++ b/helm-chart/kuberay-operator/templates/ray_raycronjob_viewer_role.yaml
@@ -1,0 +1,24 @@
+{{- /* ClusterRole for end users to view RayCronJob. */ -}}
+{{- if and .Values.rbacEnable (not .Values.singleNamespaceInstall) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: raycronjob-viewer-role
+  labels:
+    {{- include "kuberay-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - raycronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - raycronjobs/status
+  verbs:
+  - get
+{{- end }}

--- a/helm-chart/kuberay-operator/tests/configmap_test.yaml
+++ b/helm-chart/kuberay-operator/tests/configmap_test.yaml
@@ -1,0 +1,294 @@
+suite: Test ConfigMap
+
+templates:
+  - configmap.yaml
+
+release:
+  name: kuberay-operator
+  namespace: default
+
+tests:
+  - it: Should not create ConfigMap when configuration is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not create ConfigMap when configuration.enabled is false
+    set:
+      configuration:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should create ConfigMap when configuration is enabled
+    set:
+      configuration:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          apiVersion: v1
+          kind: ConfigMap
+          name: kuberay-operator-config
+          namespace: default
+
+  - it: Should create ConfigMap with defaultContainerEnvs when set
+    set:
+      configuration:
+        enabled: true
+        defaultContainerEnvs:
+          - name: RAY_enable_open_telemetry
+            value: "true"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          apiVersion: v1
+          kind: ConfigMap
+          name: kuberay-operator-config
+          namespace: default
+
+  - it: Should include defaultContainerEnvs in Configuration
+    set:
+      configuration:
+        enabled: true
+        defaultContainerEnvs:
+          - name: RAY_enable_open_telemetry
+            value: "true"
+          - name: RAY_metric_cardinality_level
+            value: "recommended"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "apiVersion: config.ray.io/v1alpha1"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "kind: Configuration"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "defaultContainerEnvs:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "name: RAY_enable_open_telemetry"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'value: "true"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "name: RAY_metric_cardinality_level"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "value: recommended"
+
+  - it: Should create ConfigMap without defaultContainerEnvs when not set
+    set:
+      configuration:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "apiVersion: config.ray.io/v1alpha1"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "kind: Configuration"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "defaultContainerEnvs:"
+
+  - it: Should include enableLeaderElection from values.leaderElectionEnabled
+    set:
+      configuration:
+        enabled: true
+      leaderElectionEnabled: false
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "enableLeaderElection: false"
+
+  - it: Should include enableMetrics from values.metrics.enabled
+    set:
+      configuration:
+        enabled: true
+      metrics:
+        enabled: false
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "enableMetrics: false"
+
+  - it: Should include reconcileConcurrency from values
+    set:
+      configuration:
+        enabled: true
+      reconcileConcurrency: 5
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "reconcileConcurrency: 5"
+
+  - it: Should include qps and burst from values.kubeClient
+    set:
+      configuration:
+        enabled: true
+      kubeClient:
+        qps: 200
+        burst: 400
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "qps: 200"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "burst: 400"
+
+  - it: Should include useKubernetesProxy from values
+    set:
+      configuration:
+        enabled: true
+      useKubernetesProxy: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "useKubernetesProxy: true"
+
+  - it: Should include watchNamespace from values
+    set:
+      configuration:
+        enabled: true
+      watchNamespace:
+        - namespace1
+        - namespace2
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'watchNamespace: "namespace1,namespace2"'
+
+  - it: Should include batchScheduler configuration
+    set:
+      configuration:
+        enabled: true
+      batchScheduler:
+        enabled: true
+        name: volcano
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "enableBatchScheduler: true"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'batchScheduler: "volcano"'
+
+  - it: Should include logging configuration
+    set:
+      configuration:
+        enabled: true
+      logging:
+        baseDir: /var/log
+        fileName: operator.log
+        stdoutEncoder: console
+        fileEncoder: json
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'logFile: "/var/log/operator.log"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'logStdoutEncoder: "console"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'logFileEncoder: "json"'
+
+  - it: Should include headSidecarContainers when set
+    set:
+      configuration:
+        enabled: true
+        headSidecarContainers:
+          - name: fluentbit
+            image: fluent/fluent-bit:1.9
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "headSidecarContainers:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "name: fluentbit"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "image: fluent/fluent-bit:1.9"
+
+  - it: Should include workerSidecarContainers when set
+    set:
+      configuration:
+        enabled: true
+        workerSidecarContainers:
+          - name: monitoring
+            image: prometheus/node-exporter:latest
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "workerSidecarContainers:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "name: monitoring"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "image: prometheus/node-exporter:latest"
+
+  - it: Should not include headSidecarContainers when not set
+    set:
+      configuration:
+        enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "headSidecarContainers:"
+
+  - it: Should not include workerSidecarContainers when not set
+    set:
+      configuration:
+        enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "workerSidecarContainers:"
+
+  - it: Should include all configurations from values when configuration.enabled is true
+    set:
+      configuration:
+        enabled: true
+        defaultContainerEnvs:
+          - name: RAY_TEST
+            value: "test"
+      leaderElectionEnabled: false
+      metrics:
+        enabled: false
+      reconcileConcurrency: 3
+      kubeClient:
+        qps: 150
+        burst: 300
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "enableLeaderElection: false"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "enableMetrics: false"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "reconcileConcurrency: 3"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "qps: 150"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "burst: 300"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "defaultContainerEnvs:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "name: RAY_TEST"

--- a/helm-chart/kuberay-operator/tests/deployment_test.yaml
+++ b/helm-chart/kuberay-operator/tests/deployment_test.yaml
@@ -267,3 +267,139 @@ tests:
             - key: key2
               operator: Exists
               effect: NoSchedule
+
+  - it: Should add priorityClassName if `priorityClassName` is set
+    set:
+      priorityClassName: high-priority
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: Should set replicas when `replicas` is set
+    set:
+      replicas: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: Should use custom reconcile concurrency when set
+    set:
+      reconcileConcurrency: 5
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--reconcile-concurrency=5"
+
+  - it: Should use custom kube client qps and burst when set
+    set:
+      kubeClient:
+        qps: 75.5
+        burst: 150
+    asserts:
+    - contains:
+        path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+        content: "--qps=75.5"
+    - contains:
+        path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+        content: "--burst=150"
+
+  - it: Should add config volume and volumeMount when configuration is enabled
+    set:
+      configuration:
+        enabled: true
+        defaultContainerEnvs:
+          - name: RAY_enable_open_telemetry
+            value: "true"
+          - name: RAY_metric_cardinality_level
+            value: "recommended"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: operator-config
+            configMap:
+              name: kuberay-operator-config
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].volumeMounts
+          content:
+            name: operator-config
+            mountPath: /etc/kuberay
+            readOnly: true
+
+  - it: Should add --config arg when configuration is enabled
+    set:
+      configuration:
+        enabled: true
+        defaultContainerEnvs:
+          - name: RAY_enable_open_telemetry
+            value: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--config"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "/etc/kuberay/config.yaml"
+
+  - it: Should not add config volume when configuration is not enabled
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name=="operator-config")]
+
+  - it: Should not include command-line flags when configuration is enabled (ConfigMap mode)
+    set:
+      configuration:
+        enabled: true
+      reconcileConcurrency: 5
+      kubeClient:
+        qps: 100
+        burst: 200
+      leaderElectionEnabled: false
+      metrics:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--config"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "/etc/kuberay/config.yaml"
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--reconcile-concurrency=5"
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--qps=100"
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--burst=200"
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--enable-leader-election=false"
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--enable-metrics=false"
+
+  - it: Should include command-line flags when configuration is disabled (command-line mode)
+    set:
+      configuration:
+        enabled: false
+      reconcileConcurrency: 5
+      kubeClient:
+        qps: 100
+        burst: 200
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--config"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--reconcile-concurrency=5"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--qps=100"
+      - contains:
+          path: spec.template.spec.containers[?(@.name=="kuberay-operator")].args
+          content: "--burst=200"

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -11,21 +11,39 @@ fullnameOverride: kuberay-operator
 # -- String to override component name.
 componentOverride: kuberay-operator
 
+# -- Number of replicas for the KubeRay operator Deployment.
+replicas: 1
+
 image:
   # -- Image repository.
   repository: quay.io/kuberay/operator
 
   # -- Image tag.
-  tag: v1.4.2
+  tag: v1.6.0-rc.0
 
   # -- Image pull policy.
   pullPolicy: IfNotPresent
+
+# -- Secrets with credentials to pull images from a private registry
+imagePullSecrets: []
+
+# -- Restrict to run on particular nodes.
+nodeSelector: {}
+
+# -- Pod priorityClassName
+priorityClassName: ""
 
 # -- Extra labels.
 labels: {}
 
 # -- Extra annotations.
 annotations: {}
+
+# -- Pod affinity
+affinity: {}
+
+# -- Pod tolerations
+tolerations: []
 
 serviceAccount:
   # -- Specifies whether a service account should be created.
@@ -70,19 +88,59 @@ logging:
 #  4. Use PodGroup
 #       batchScheduler:
 #         name: scheduler-plugins
-#
+
+#  5. Use Kai Scheduler
+#       batchScheduler:
+#         name: kai-scheduler
+
 batchScheduler:
   # Deprecated. This option will be removed in the future.
   # Note, for backwards compatibility. When it sets to true, it enables volcano scheduler integration.
   enabled: false
-  # Set the customized scheduler name, supported values are "volcano" or "yunikorn", do not set
+  # Set the customized scheduler name, supported values are "volcano", "yunikorn", "kai-scheduler" or "scheduler-plugins", do not set
   # "batchScheduler.enabled=true" at the same time as it will override this option.
   name: ""
+
+# Configuration for the KubeRay operator.
+configuration:
+  # -- Whether to enable the configuration feature. If enabled, a ConfigMap will be created and mounted to the operator.
+  # When enabled, flag-based configuration values (leaderElectionEnabled, metrics.enabled, kubeClient.qps, etc.)
+  # will be injected into the ConfigMap. The operator will use the ConfigMap and ignore command-line flags.
+  enabled: false
+  # -- Default environment variables to inject into all Ray containers in all RayCluster CRs.
+  # This allows user to set feature flags across all Ray pods.
+  # Example:
+  # defaultContainerEnvs:
+  # - name: RAY_enable_open_telemetry
+  #   value: "true"
+  # - name: RAY_metric_cardinality_level
+  #   value: "recommended"
+  defaultContainerEnvs: []
+
+  # -- Sidecar containers to inject into every Ray head pod.
+  # Example:
+  # headSidecarContainers:
+  # - name: fluentbit
+  #   image: fluent/fluent-bit:1.9
+  headSidecarContainers: []
+
+  # -- Sidecar containers to inject into every Ray worker pod.
+  # Example:
+  # workerSidecarContainers:
+  # - name: fluentbit
+  #   image: fluent/fluent-bit:1.9
+  workerSidecarContainers: []
 
 featureGates:
 - name: RayClusterStatusConditions
   enabled: true
 - name: RayJobDeletionPolicy
+  enabled: true
+- name: RayMultiHostIndexing
+  enabled: true
+- name: RayServiceIncrementalUpgrade
+  enabled: false
+- name: RayCronJob
   enabled: false
 
 # Configurations for KubeRay operator metrics.
@@ -111,6 +169,22 @@ operatorCommand: /manager
 
 # -- If leaderElectionEnabled is set to true, the KubeRay operator will use leader election for high availability.
 leaderElectionEnabled: true
+
+# -- The maximum number of reconcile operations that can be performed simultaneously.
+# This setting controls the concurrency of the controller reconciliation loops.
+# Higher values can improve throughput in clusters with many resources, but may increase resource consumption.
+reconcileConcurrency: 1
+
+# -- Kube Client configuration for QPS and burst settings.
+# This setting controls the QPS and burst rate of the kube client when sending requests to the Kubernetes API server.
+# If the QPS and burst values are too low, we may easily hit rate limits on the API server and slow down the controller reconciliation loops.
+kubeClient:
+  # -- The QPS value for the client communicating with the Kubernetes API server.
+  # Must be a float number.
+  qps: 100.0
+  # -- The maximum burst for throttling requests from this client to the Kubernetes API server.
+  # Must be a non-negative integer.
+  burst: 200
 
 # -- If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
 rbacEnable: true
@@ -176,6 +250,23 @@ env:
 # If set to true, the RayJob CR itself will be deleted if shutdownAfterJobFinishes is set to true. Note that all resources created by the RayJob CR will be deleted, including the K8s Job. Otherwise, only the RayCluster CR will be deleted. Default is false.
 # - name: DELETE_RAYJOB_CR_AFTER_JOB_FINISHES
 #   value: "false"
+# If set to true, we will use deterministic name for head pod. Otherwise, the non-deterministic name is used.
+# - name: ENABLE_DETERMINISTIC_HEAD_POD_NAME
+#   value: "false"
+# This environment variable determines whether to enable a login shell by passing the -l option to the container command /bin/bash.
+# The -l flag was added by default before KubeRay v1.4.0, but it is no longer added by default starting with v1.4.0.
+# - name: ENABLE_LOGIN_SHELL
+#   value: "true"
+# This KubeRay operator environment variable is used to determine if random Pod
+# deletion should be enabled. Note that this only takes effect when autoscaling
+# is enabled for the RayCluster.
+# - name: ENABLE_RANDOM_POD_DELETE
+#   value: "false"
+# If JobDeploymentStatus does not transition to Complete or Failed within
+# this grace period seconds after JobStatus reaches a terminal state,
+# KubeRay will update JobDeploymentStatus directly.
+# - name: RAYJOB_DEPLOYMENT_STATUS_TRANSITION_GRACE_PERIOD_SECONDS
+#   value: "300"
 
 # -- Resource requests and limits for containers.
 resources:

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
+
 name: ray-cluster
-version: 1.4.2
+
+description: A Helm chart for deploying the RayCluster with the kuberay operator.
+
+version: 1.6.0-rc.0
+
+home: https://github.com/ray-project/kuberay
+
 icon: https://github.com/ray-project/ray/raw/master/doc/source/images/ray_header_logo.png

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -30,15 +30,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.1.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+# Step 3: Install both CRDs and KubeRay operator v1.6.0-rc.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.1.0
+helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -1,8 +1,17 @@
 # RayCluster
 
-RayCluster is a custom resource definition (CRD). **KubeRay operator** will listen to the resource
-events about RayCluster and create related Kubernetes resources (e.g. Pod & Service). Hence,
-**KubeRay operator** installation and **CRD** registration are required for this guide.
+![Version: 1.6.0-rc.0](https://img.shields.io/badge/Version-1.6.0--rc.0-informational?style=flat-square)
+
+A Helm chart for deploying the RayCluster with the kuberay operator.
+
+**Homepage:** <https://github.com/ray-project/kuberay>
+
+## Introduction
+
+RayCluster is a custom resource definition (CRD).
+KubeRay operator will listen to the resource events about RayCluster and create related Kubernetes resources
+(e.g. Pod & Service).
+Hence, KubeRay operator installation and CRD registration are required for this guide.
 
 ## Prerequisites
 
@@ -58,3 +67,106 @@ helm uninstall raycluster
 ```
 
 [kuberay-operator/README.md]: https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.repository | string | `"rayproject/ray"` | Image repository. |
+| image.tag | string | `"2.52.0"` | Image tag. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| nameOverride | string | `"kuberay"` | String to partially override release name. |
+| fullnameOverride | string | `""` | String to fully override release name. |
+| imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
+| gcsFaultTolerance.enabled | bool | `false` |  |
+| common.containerEnv | list | `[]` | containerEnv specifies environment variables for the Ray head and worker containers. Follows standard K8s container env schema. |
+| head.initContainers | list | `[]` | Init containers to add to the head pod |
+| head.labels | object | `{}` | Labels for the head pod |
+| head.serviceAccountName | string | `""` |  |
+| head.restartPolicy | string | `""` |  |
+| head.runtimeClassName | string | `""` | runtimeClassName is the name of the RuntimeClass to use to run the head Pod. |
+| head.containerEnv | list | `[]` |  |
+| head.envFrom | list | `[]` | envFrom to pass to head pod |
+| head.resources.limits.cpu | string | `"1"` |  |
+| head.resources.limits.memory | string | `"2G"` |  |
+| head.resources.requests.cpu | string | `"1"` |  |
+| head.resources.requests.memory | string | `"2G"` |  |
+| head.resourceClaims | list | `[]` | ResourceClaims to allocate with the head pod |
+| head.annotations | object | `{}` | Extra annotations for head pod |
+| head.nodeSelector | object | `{}` | Node labels for head pod assignment |
+| head.tolerations | list | `[]` | Node tolerations for head pod scheduling to nodes with taints |
+| head.affinity | object | `{}` | Head pod affinity |
+| head.podSecurityContext | object | `{}` | Head pod security context. |
+| head.securityContext | object | `{}` | Ray container security context. |
+| head.volumes[0].name | string | `"log-volume"` |  |
+| head.volumes[0].emptyDir | object | `{}` |  |
+| head.volumeMounts[0].mountPath | string | `"/tmp/ray"` |  |
+| head.volumeMounts[0].name | string | `"log-volume"` |  |
+| head.sidecarContainers | list | `[]` |  |
+| head.command | list | `[]` |  |
+| head.args | list | `[]` |  |
+| head.headService | object | `{}` |  |
+| head.topologySpreadConstraints | list | `[]` |  |
+| head.rayStartParams | object | `{}` |  |
+| worker.groupName | string | `"workergroup"` | The name of the workergroup |
+| worker.replicas | int | `1` | The number of replicas for the worker pod |
+| worker.minReplicas | int | `1` | The minimum number of replicas for the worker pod |
+| worker.maxReplicas | int | `3` | The maximum number of replicas for the worker pod |
+| worker.labels | object | `{}` | Labels for the worker pod |
+| worker.serviceAccountName | string | `""` |  |
+| worker.restartPolicy | string | `""` |  |
+| worker.runtimeClassName | string | `""` | runtimeClassName is the name of the RuntimeClass to use to run the worker Pods. |
+| worker.initContainers | list | `[]` | Init containers to add to the worker pod |
+| worker.containerEnv | list | `[]` |  |
+| worker.envFrom | list | `[]` | envFrom to pass to worker pod |
+| worker.resources.limits.cpu | string | `"1"` |  |
+| worker.resources.limits.memory | string | `"1G"` |  |
+| worker.resources.requests.cpu | string | `"1"` |  |
+| worker.resources.requests.memory | string | `"1G"` |  |
+| worker.resourceClaims | list | `[]` | ResourceClaims to allocate with the worker pod |
+| worker.annotations | object | `{}` | Extra annotations for worker pod |
+| worker.nodeSelector | object | `{}` | Node labels for worker pod assignment |
+| worker.tolerations | list | `[]` | Node tolerations for worker pod scheduling to nodes with taints |
+| worker.affinity | object | `{}` | Worker pod affinity |
+| worker.podSecurityContext | object | `{}` | Worker pod security context. |
+| worker.securityContext | object | `{}` | Ray container security context. |
+| worker.volumes[0].name | string | `"log-volume"` |  |
+| worker.volumes[0].emptyDir | object | `{}` |  |
+| worker.volumeMounts[0].mountPath | string | `"/tmp/ray"` |  |
+| worker.volumeMounts[0].name | string | `"log-volume"` |  |
+| worker.sidecarContainers | list | `[]` |  |
+| worker.command | list | `[]` |  |
+| worker.args | list | `[]` |  |
+| worker.topologySpreadConstraints | list | `[]` |  |
+| worker.rayStartParams | object | `{}` |  |
+| additionalWorkerGroups.smallGroup.disabled | bool | `true` |  |
+| additionalWorkerGroups.smallGroup.replicas | int | `0` | The number of replicas for the additional worker pod |
+| additionalWorkerGroups.smallGroup.minReplicas | int | `0` | The minimum number of replicas for the additional worker pod |
+| additionalWorkerGroups.smallGroup.maxReplicas | int | `3` | The maximum number of replicas for the additional worker pod |
+| additionalWorkerGroups.smallGroup.labels | object | `{}` | Labels for the additional worker pod |
+| additionalWorkerGroups.smallGroup.serviceAccountName | string | `""` |  |
+| additionalWorkerGroups.smallGroup.restartPolicy | string | `""` |  |
+| additionalWorkerGroups.smallGroup.runtimeClassName | string | `""` | runtimeClassName for this additional worker group. Empty string means default runtime. |
+| additionalWorkerGroups.smallGroup.containerEnv | list | `[]` |  |
+| additionalWorkerGroups.smallGroup.envFrom | list | `[]` | envFrom to pass to additional worker pod |
+| additionalWorkerGroups.smallGroup.resources.limits.cpu | int | `1` |  |
+| additionalWorkerGroups.smallGroup.resources.limits.memory | string | `"1G"` |  |
+| additionalWorkerGroups.smallGroup.resources.requests.cpu | int | `1` |  |
+| additionalWorkerGroups.smallGroup.resources.requests.memory | string | `"1G"` |  |
+| additionalWorkerGroups.smallGroup.resourceClaims | list | `[]` | ResourceClaims to allocate with the additional worker pod |
+| additionalWorkerGroups.smallGroup.annotations | object | `{}` | Extra annotations for additional worker pod |
+| additionalWorkerGroups.smallGroup.nodeSelector | object | `{}` | Node labels for additional worker pod assignment |
+| additionalWorkerGroups.smallGroup.tolerations | list | `[]` | Node tolerations for additional worker pod scheduling to nodes with taints |
+| additionalWorkerGroups.smallGroup.affinity | object | `{}` | Additional worker pod affinity |
+| additionalWorkerGroups.smallGroup.podSecurityContext | object | `{}` | Additional worker pod security context. |
+| additionalWorkerGroups.smallGroup.securityContext | object | `{}` | Ray container security context. |
+| additionalWorkerGroups.smallGroup.volumes[0].name | string | `"log-volume"` |  |
+| additionalWorkerGroups.smallGroup.volumes[0].emptyDir | object | `{}` |  |
+| additionalWorkerGroups.smallGroup.volumeMounts[0].mountPath | string | `"/tmp/ray"` |  |
+| additionalWorkerGroups.smallGroup.volumeMounts[0].name | string | `"log-volume"` |  |
+| additionalWorkerGroups.smallGroup.sidecarContainers | list | `[]` |  |
+| additionalWorkerGroups.smallGroup.command | list | `[]` |  |
+| additionalWorkerGroups.smallGroup.args | list | `[]` |  |
+| additionalWorkerGroups.smallGroup.topologySpreadConstraints | list | `[]` |  |
+| additionalWorkerGroups.smallGroup.rayStartParams | object | `{}` |  |
+| service.type | string | `"ClusterIP"` |  |

--- a/helm-chart/ray-cluster/README.md.gotmpl
+++ b/helm-chart/ray-cluster/README.md.gotmpl
@@ -1,0 +1,73 @@
+# RayCluster
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Introduction
+
+RayCluster is a custom resource definition (CRD).
+KubeRay operator will listen to the resource events about RayCluster and create related Kubernetes resources
+(e.g. Pod & Service).
+Hence, KubeRay operator installation and CRD registration are required for this guide.
+
+## Prerequisites
+
+See [kuberay-operator/README.md] for more details.
+
+* Helm
+* Install custom resource definition and KubeRay operator (covered by the following end-to-end
+  example.)
+
+## End-to-end example
+
+```sh
+# Step 1: Create a KinD cluster
+kind create cluster
+
+# Step 2: Register a Helm chart repo
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+
+# Step 3: Install both CRDs and KubeRay operator v1.1.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+
+# Step 4: Install a RayCluster custom resource
+# (For x86_64 users)
+helm install raycluster kuberay/ray-cluster --version 1.1.0
+# (For arm64 users, e.g. Mac M1)
+# See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
+helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
+
+# Step 5: Verify the installation of KubeRay operator and RayCluster
+kubectl get pods
+# NAME                                          READY   STATUS    RESTARTS   AGE
+# kuberay-operator-6fcbb94f64-gkpc9             1/1     Running   0          89s
+# raycluster-kuberay-head-qp9f4                 1/1     Running   0          66s
+# raycluster-kuberay-worker-workergroup-2jckt   1/1     Running   0          66s
+
+# Step 6: Forward the port of Dashboard
+kubectl port-forward svc/raycluster-kuberay-head-svc 8265:8265
+
+# Step 7: Check 127.0.0.1:8265 for the Dashboard
+
+# Step 8: Log in to Ray head Pod and execute a job.
+kubectl exec -it ${RAYCLUSTER_HEAD_POD} -- bash
+python -c "import ray; ray.init(); print(ray.cluster_resources())" # (in Ray head Pod)
+
+# Step 9: Check 127.0.0.1:8265/#/job. The status of the job should be "SUCCEEDED".
+
+# Step 10: Uninstall RayCluster
+helm uninstall raycluster
+
+# Step 11: Verify that RayCluster has been removed successfully
+# NAME                                READY   STATUS    RESTARTS   AGE
+# kuberay-operator-6fcbb94f64-gkpc9   1/1     Running   0          9m57s
+```
+
+[kuberay-operator/README.md]: https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md
+
+{{ template "chart.valuesSection" . }}

--- a/helm-chart/ray-cluster/README.md.gotmpl
+++ b/helm-chart/ray-cluster/README.md.gotmpl
@@ -32,15 +32,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.1.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+# Step 3: Install both CRDs and KubeRay operator v1.6.0-rc.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.1.0
+helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods

--- a/helm-chart/ray-cluster/ci/ci-values.yaml
+++ b/helm-chart/ray-cluster/ci/ci-values.yaml
@@ -1,3 +1,3 @@
 image:
   repository: rayproject/ray
-  tag: 2.46.0
+  tag: 2.52.0

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -20,6 +20,21 @@ spec:
   autoscalerOptions:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.gcsFaultTolerance.enabled }}
+  gcsFaultToleranceOptions:
+    redisAddress: {{ .Values.gcsFaultTolerance.redisAddress | quote }}
+    {{- with .Values.gcsFaultTolerance.externalStorageNamespace }}
+    externalStorageNamespace: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.gcsFaultTolerance.redisPassword }}
+    redisPassword:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.gcsFaultTolerance.redisUsername }}
+    redisUsername:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
   headGroupSpec:
     {{- with .Values.head.headService }}
     headService:
@@ -38,7 +53,6 @@ spec:
         {{ $key }}: {{ $val | quote }}
       {{- end }}
     {{- else }}
-    rayStartParams: {}
     {{- end }}
     template:
       metadata:
@@ -141,11 +155,18 @@ spec:
         {{- with .Values.head.restartPolicy }}
         restartPolicy: {{ . }}
         {{- end }}
+        {{- with .Values.head.runtimeClassName }}
+        runtimeClassName: {{ . }}
+        {{- end }}
         {{- with .Values.head.serviceAccountName }}
         serviceAccountName: {{ . }}
         {{- end }}
         {{- with .Values.head.podSecurityContext }}
         securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.head.resourceClaims }}
+        resourceClaims:
           {{- toYaml . | nindent 10 }}
         {{- end }}
   workerGroupSpecs:
@@ -165,7 +186,6 @@ spec:
       {{ $key }}: {{ $val | quote }}
       {{- end }}
     {{- else }}
-    rayStartParams: {}
     {{- end }}
     template:
       metadata:
@@ -268,11 +288,18 @@ spec:
         {{- with .Values.worker.restartPolicy }}
         restartPolicy: {{ . }}
         {{- end }}
+        {{- with .Values.worker.runtimeClassName }}
+        runtimeClassName: {{ . }}
+        {{- end }}
         {{- with .Values.worker.serviceAccountName }}
         serviceAccountName: {{ . }}
         {{- end }}
         {{- with .Values.worker.podSecurityContext }}
         securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.worker.resourceClaims }}
+        resourceClaims:
           {{- toYaml . | nindent 10 }}
         {{- end }}
   {{- end }}
@@ -293,7 +320,6 @@ spec:
         {{ $key }}: {{ $val | quote }}
       {{- end }}
     {{- else }}
-    rayStartParams: {}
     {{- end }}
     template:
       metadata:
@@ -351,6 +377,14 @@ spec:
           {{- with $values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- else }}
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1G"
+            requests:
+              cpu: "1"
+              memory: "1G"
           {{- end }}
           {{- with $values.securityContext }}
           securityContext:
@@ -396,11 +430,18 @@ spec:
         {{- with $values.restartPolicy }}
         restartPolicy: {{ . }}
         {{- end }}
+        {{- with $values.runtimeClassName }}
+        runtimeClassName: {{ . }}
+        {{- end }}
         {{- with $values.serviceAccountName }}
         serviceAccountName: {{ . }}
         {{- end }}
         {{- with $values.podSecurityContext }}
         securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $values.resourceClaims }}
+        resourceClaims:
           {{- toYaml . | nindent 10 }}
         {{- end }}
   {{- end }}

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -19,11 +19,11 @@ tests:
   - it: Should set Ray version when `head.rayVersion` is set
     set:
       head:
-        rayVersion: 2.46.0
+        rayVersion: 2.52.0
     asserts:
       - equal:
           path: spec.rayVersion
-          value: 2.46.0
+          value: 2.52.0
 
   - it: Should enable in-tree auto scaling when `head.enableInTreeAutoscaling` is `true`
     set:
@@ -96,6 +96,33 @@ tests:
               runAsNonRoot: true
               seccompProfile:
                 type: RuntimeDefault
+
+  - it: Should add GCS fault tolerance options when `gcsFaultTolerance.enabled` is `true`
+    set:
+      gcsFaultTolerance:
+        enabled: true
+        redisAddress: "test-redis:6379"
+        externalStorageNamespace: "test-gcs-namespace"
+        redisPassword:
+          valueFrom:
+            secretKeyRef:
+              name: redis-secret
+              key: password
+        redisUsername:
+          value: "test-user"
+    asserts:
+      - equal:
+          path: spec.gcsFaultToleranceOptions
+          value:
+            redisAddress: "test-redis:6379"
+            externalStorageNamespace: "test-gcs-namespace"
+            redisPassword:
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
+            redisUsername:
+              value: "test-user"
 
   # ===========================================================================
   # Test Head Group
@@ -772,6 +799,19 @@ tests:
           path: spec.headGroupSpec.template.spec.securityContext.fsGroup
           value: 3000
 
+  - it: Should add resource claims if `head.resourceClaims` is set
+    set:
+      head:
+        resourceClaims:
+          - name: gpu
+            resourceClaimName: gpu-claim
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.resourceClaims
+          value:
+            - name: gpu
+              resourceClaimName: gpu-claim
+
   # ===========================================================================
   # Test Default Worker Group
   # ===========================================================================
@@ -1419,6 +1459,19 @@ tests:
           path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.securityContext.fsGroup
           value: 3000
 
+  - it: Should add resource claims if `worker.resourceClaims` is set
+    set:
+      worker:
+        resourceClaims:
+          - name: gpu
+            resourceClaimName: gpu-claim
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.resourceClaims
+          value:
+            - name: gpu
+              resourceClaimName: gpu-claim
+
   # ===========================================================================
   # Test Additional Worker Groups
   # ===========================================================================
@@ -1789,6 +1842,23 @@ tests:
               memory: 128Mi
               cpu: 500m
 
+  - it: Should add default resources if `additionalWorkerGroups.smallGroup.resources` is not set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          resources: null
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.containers[?(@.name=="ray-worker")].resources
+          value:
+            limits:
+              cpu: "1"
+              memory: 1G
+            requests:
+              cpu: "1"
+              memory: 1G
+
   - it: Should add lifecycle if `additionalWorkerGroups.smallGroup.lifecycle` is set
     set:
       additionalWorkerGroups:
@@ -2126,3 +2196,47 @@ tests:
       - equal:
           path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.securityContext.fsGroup
           value: 3000
+
+  - it: Should add resource claims if `additionalWorkerGroups.smallGroup.resourceClaims` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          resourceClaims:
+            - name: gpu
+              resourceClaimName: gpu-claim
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.resourceClaims
+          value:
+            - name: gpu
+              resourceClaimName: gpu-claim
+
+  - it: Should set head runtimeClassName when `head.runtimeClassName` is set
+    set:
+      head:
+        runtimeClassName: nvidia
+    asserts:
+      - equal:
+          path: spec.headGroupSpec.template.spec.runtimeClassName
+          value: nvidia
+
+  - it: Should set worker runtimeClassName when `worker.runtimeClassName` is set
+    set:
+      worker:
+        runtimeClassName: nvidia
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="workergroup")].template.spec.runtimeClassName
+          value: nvidia
+
+  - it: Should set additional worker group runtimeClassName when `additionalWorkerGroups.smallGroup.runtimeClassName` is set
+    set:
+      additionalWorkerGroups:
+        smallGroup:
+          disabled: false
+          runtimeClassName: nvidia
+    asserts:
+      - equal:
+          path: spec.workerGroupSpecs[?(@.groupName=="smallGroup")].template.spec.runtimeClassName
+          value: nvidia

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -6,19 +6,52 @@
 # in this Helm chart.
 
 image:
+  # -- Image repository.
   repository: rayproject/ray
-  tag: 2.46.0
+  # -- Image tag.
+  tag: 2.52.0
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
 
+# -- String to partially override release name.
 nameOverride: "kuberay"
+
+# -- String to fully override release name.
 fullnameOverride: ""
 
+# -- Secrets with credentials to pull images from a private registry
 imagePullSecrets: []
   # - name: an-existing-secret
 
+# gcsFaultTolerance specifies configuration for GCS fault tolerance.
+# See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-gcs-ft.html#kuberay-gcs-ft
+# for more details.
+gcsFaultTolerance:
+  enabled: false
+  # In most cases, you don't need to set `externalStorageNamespace` because KubeRay will
+  # automatically set it to the UID of RayCluster. Only modify this annotation if you fully understand
+  # the behaviors of the Ray GCS FT and RayService to avoid misconfiguration.
+  # externalStorageNamespace: "my-raycluster-storage"
+  # redisAddress: "redis:6379"
+  # redisPassword:
+    # Reference to a secret key containing the Redis password
+    # Secret must be manually created in the namespace
+    # valueFrom:
+    #   secretKeyRef:
+    #       name: redis-password-secret
+    #       key: password
+  # redisUsername:
+    # Reference to a secret key containing the Redis username
+    # Secret must be manually created in the namespace
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: redis-username-secret
+    #     key: username
+
+
 # common defined values shared between the head and worker
 common:
-  # containerEnv specifies environment variables for the Ray head and worker containers.
+  # -- containerEnv specifies environment variables for the Ray head and worker containers.
   # Follows standard K8s container env schema.
   containerEnv: []
   #  - name: BLAH
@@ -26,11 +59,13 @@ common:
 head:
   # rayVersion determines the autoscaler's image version.
   # It should match the Ray version in the image of the containers.
-  # rayVersion: 2.46.0
+  # rayVersion: 2.52.0
+
   # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
   # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
   # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
   # enableInTreeAutoscaling: true
+
   # autoscalerOptions is an OPTIONAL field specifying configuration overrides for the Ray autoscaler.
   # The example configuration shown below represents the DEFAULT values.
   # autoscalerOptions:
@@ -52,23 +87,34 @@ head:
     #   requests:
     #     cpu: "500m"
     #     memory: "512Mi"
+
+  # -- Init containers to add to the head pod
   initContainers: []
+  # -- Labels for the head pod
   labels: {}
+
   # Note: From KubeRay v0.6.0, users need to create the ServiceAccount by themselves if they specify the `serviceAccountName`
   # in the headGroupSpec. See https://github.com/ray-project/kuberay/pull/1128 for more details.
   serviceAccountName: ""
   restartPolicy: ""
-  rayStartParams: {}
+
+  # -- runtimeClassName is the name of the RuntimeClass to use to run the head Pod.
+  runtimeClassName: ""
+
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
   # - name: EXAMPLE_ENV
   #   value: "1"
+
+  # -- envFrom to pass to head pod
   envFrom: []
     # - secretRef:
     #     name: my-env-secret
+
   # ports optionally allows specifying ports for the Ray container.
   # ports: []
+
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
   # Note that the resources in this example are much too small for production;
@@ -86,14 +132,28 @@ head:
     requests:
       cpu: "1"
       memory: "2G"
+
+  # -- ResourceClaims to allocate with the head pod
+  resourceClaims: []
+
+  # -- Extra annotations for head pod
   annotations: {}
+
+  # -- Node labels for head pod assignment
   nodeSelector: {}
+
+  # -- Node tolerations for head pod scheduling to nodes with taints
   tolerations: []
+
+  # -- Head pod affinity
   affinity: {}
-  # Pod security context.
+
+  # -- Head pod security context.
   podSecurityContext: {}
-  # Ray container security context.
+
+  # -- Ray container security context.
   securityContext: {}
+
   # Optional: The following volumes/volumeMounts configurations are optional but recommended because
   # Ray writes logs to /tmp/ray/session_latests/logs instead of stdout/stderr.
   volumes:
@@ -102,13 +162,16 @@ head:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+
   # sidecarContainers specifies additional containers to attach to the Ray pod.
   # Follows standard K8s container spec.
   sidecarContainers: []
+
   # See docs/guidance/pod-command.md for more details about how to specify
   # container command for head Pod.
   command: []
   args: []
+
   # Optional, for the user to provide any additional fields to the service.
   # See https://pkg.go.dev/k8s.io/Kubernetes/pkg/api/v1#Service
   headService: {}
@@ -129,30 +192,51 @@ head:
   #     - name: edns0
   topologySpreadConstraints: []
 
+  # https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html#set-the-raystartparams-and-the-resource-limits-for-the-ray-container
+  rayStartParams: {}
 
 worker:
   # If you want to disable the default workergroup
   # uncomment the line below
   # disabled: true
+
+  # -- The name of the workergroup
   groupName: workergroup
+
+  # -- The number of replicas for the worker pod
   replicas: 1
+
+  # -- The minimum number of replicas for the worker pod
   minReplicas: 1
+
+  # -- The maximum number of replicas for the worker pod
   maxReplicas: 3
+
+  # -- Labels for the worker pod
   labels: {}
   serviceAccountName: ""
   restartPolicy: ""
-  rayStartParams: {}
+
+  # -- runtimeClassName is the name of the RuntimeClass to use to run the worker Pods.
+  runtimeClassName: ""
+
+  # -- Init containers to add to the worker pod
   initContainers: []
+
   # containerEnv specifies environment variables for the Ray container,
   # Follows standard K8s container env schema.
   containerEnv: []
   # - name: EXAMPLE_ENV
   #   value: "1"
+
+  # -- envFrom to pass to worker pod
   envFrom: []
     # - secretRef:
     #     name: my-env-secret
+
   # ports optionally allows specifying ports for the Ray container.
   # ports: []
+
   # resource requests and limits for the Ray head container.
   # Modify as needed for your application.
   # Note that the resources in this example are much too small for production;
@@ -169,14 +253,28 @@ worker:
     requests:
       cpu: "1"
       memory: "1G"
+
+  # -- ResourceClaims to allocate with the worker pod
+  resourceClaims: []
+
+  # -- Extra annotations for worker pod
   annotations: {}
+
+  # -- Node labels for worker pod assignment
   nodeSelector: {}
+
+  # -- Node tolerations for worker pod scheduling to nodes with taints
   tolerations: []
+
+  # -- Worker pod affinity
   affinity: {}
-  # Pod security context.
+
+  # -- Worker pod security context.
   podSecurityContext: {}
-  # Ray container security context.
+
+  # -- Ray container security context.
   securityContext: {}
+
   # Optional: The following volumes/volumeMounts configurations are optional but recommended because
   # Ray writes logs to /tmp/ray/session_latests/logs instead of stdout/stderr.
   volumes:
@@ -185,15 +283,19 @@ worker:
   volumeMounts:
     - mountPath: /tmp/ray
       name: log-volume
+
   # sidecarContainers specifies additional containers to attach to the Ray pod.
   # Follows standard K8s container spec.
   sidecarContainers: []
+
   # See docs/guidance/pod-command.md for more details about how to specify
   # container command for worker Pod.
   command: []
   args: []
   topologySpreadConstraints: []
 
+  # https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html#set-the-raystartparams-and-the-resource-limits-for-the-ray-container
+  rayStartParams: {}
 
   # Custom pod DNS configuration
   # See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
@@ -214,23 +316,38 @@ additionalWorkerGroups:
   smallGroup:
     # Disabled by default
     disabled: true
+
+    # -- The number of replicas for the additional worker pod
     replicas: 0
+
+    # -- The minimum number of replicas for the additional worker pod
     minReplicas: 0
+
+    # -- The maximum number of replicas for the additional worker pod
     maxReplicas: 3
+
+    # -- Labels for the additional worker pod
     labels: {}
     serviceAccountName: ""
     restartPolicy: ""
-    rayStartParams: {}
+
+    # -- runtimeClassName for this additional worker group. Empty string means default runtime.
+    runtimeClassName: ""
+
     # containerEnv specifies environment variables for the Ray container,
     # Follows standard K8s container env schema.
     containerEnv: []
       # - name: EXAMPLE_ENV
       #   value: "1"
+
+    # -- envFrom to pass to additional worker pod
     envFrom: []
         # - secretRef:
         #     name: my-env-secret
+
     # ports optionally allows specifying ports for the Ray container.
     # ports: []
+
     # resource requests and limits for the Ray head container.
     # Modify as needed for your application.
     # Note that the resources in this example are much too small for production;
@@ -247,14 +364,28 @@ additionalWorkerGroups:
       requests:
         cpu: 1
         memory: "1G"
+
+    # -- ResourceClaims to allocate with the additional worker pod
+    resourceClaims: []
+
+    # -- Extra annotations for additional worker pod
     annotations: {}
+
+    # -- Node labels for additional worker pod assignment
     nodeSelector: {}
+
+    # -- Node tolerations for additional worker pod scheduling to nodes with taints
     tolerations: []
+
+    # -- Additional worker pod affinity
     affinity: {}
-    # Pod security context.
+
+    # -- Additional worker pod security context.
     podSecurityContext: {}
-    # Ray container security context.
+
+    # -- Ray container security context.
     securityContext: {}
+
     # Optional: The following volumes/volumeMounts configurations are optional but recommended because
     # Ray writes logs to /tmp/ray/session_latests/logs instead of stdout/stderr.
     volumes:
@@ -263,7 +394,9 @@ additionalWorkerGroups:
     volumeMounts:
       - mountPath: /tmp/ray
         name: log-volume
+
     sidecarContainers: []
+
     # See docs/guidance/pod-command.md for more details about how to specify
     # container command for worker Pod.
     command: []
@@ -284,6 +417,10 @@ additionalWorkerGroups:
     #     - name: ndots
     #       value: "2"
     #     - name: edns0
+
+    # https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html#set-the-raystartparams-and-the-resource-limits-for-the-ray-container
+    rayStartParams: {}
+
 
 # Configuration for Head's Kubernetes Service
 service:


### PR DESCRIPTION
note:
we should consider delete kuberay's README to reduce maintenence burden.

  - Bump chart versions and image tags to 1.6.0-rc.0
  - Add RayCronJob CRD and RBAC roles
  - Add operator ConfigMap-based configuration support (defaultContainerEnvs, sidecar injection)
  - Add reconcileConcurrency, kubeClient QPS/burst, priorityClassName, and replicas to operator values
  - Add new feature gates: RayMultiHostIndexing, RayServiceIncrementalUpgrade, RayCronJob
  - Enable RayJobDeletionPolicy and RayMultiHostIndexing by default
  - Add GCS fault tolerance support to ray-cluster chart
  - Fix apiserver ingress/route/service name mismatch bug
  - Update RBAC: add gateway API, secrets, pods/resize, endpointslices permissions
  - Add kai-scheduler support for batch scheduling
  - Add helm-docs templates for ray-cluster and kuberay-apiserver
  - Update Ray image to 2.52.0 in CI values