### PR TITLE
[Release] Release v1.6.0 helm chart

### DIFF
--- a/helm-chart/kuberay-apiserver/Chart.yaml
+++ b/helm-chart/kuberay-apiserver/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0-rc.0
+version: 1.6.0

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -29,7 +29,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0 --set security=null
 ```
 
 - Install the nightly version
@@ -52,7 +52,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0
 ```
 
 - Install the nightly version
@@ -79,7 +79,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/README.md
+++ b/helm-chart/kuberay-apiserver/README.md
@@ -1,6 +1,6 @@
 # KubeRay APIServer
 
-![Version: 1.6.0-rc.0](https://img.shields.io/badge/Version-1.6.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for kuberay-apiserver
 
@@ -29,7 +29,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
 ```
 
 - Install the nightly version
@@ -52,7 +52,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
 ```
 
 - Install the nightly version
@@ -79,7 +79,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0-rc.0
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
 ```
 
 ## Uninstall the Chart
@@ -103,7 +103,7 @@ kubectl get pods
 | replicaCount | int | `1` |  |
 | name | string | `"kuberay-apiserver"` |  |
 | image.repository | string | `"quay.io/kuberay/apiserver"` | Image repository. |
-| image.tag | string | `"v1.6.0-rc.0"` | Image tag. |
+| image.tag | string | `"v1.6.0"` | Image tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | cors | string | `nil` |  |
 | labels | object | `{}` | Extra labels. |

--- a/helm-chart/kuberay-apiserver/README.md.gotmpl
+++ b/helm-chart/kuberay-apiserver/README.md.gotmpl
@@ -34,7 +34,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0 --set security=null
 ```
 
 - Install the nightly version
@@ -57,7 +57,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0
 ```
 
 - Install the nightly version
@@ -84,7 +84,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/README.md.gotmpl
+++ b/helm-chart/kuberay-apiserver/README.md.gotmpl
@@ -34,7 +34,7 @@ helm version
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer without security proxy
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0 --set security=null
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2 --set security=null
 ```
 
 - Install the nightly version
@@ -57,7 +57,7 @@ helm install kuberay-apiserver . --set security=null
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 # Install KubeRay APIServer
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.6.0
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version 1.4.2
 ```
 
 - Install the nightly version
@@ -84,7 +84,7 @@ To list the `kuberay-apiserver` release:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART
-# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.6.0-rc.0
+# kuberay-apiserver       default         1               2025-08-08 17:07:51.472353906 +0000 UTC deployed        kuberay-apiserver-1.4.2
 ```
 
 ## Uninstall the Chart

--- a/helm-chart/kuberay-apiserver/templates/ingress.yaml
+++ b/helm-chart/kuberay-apiserver/templates/ingress.yaml
@@ -2,18 +2,7 @@
 {{- $fullName := include "kuberay-apiserver.fullname" . -}}
 {{- $svcName := printf "%s-service" $fullName -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -25,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
@@ -45,19 +34,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $svcName }}
                 port:
                   number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $svcName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
+++ b/helm-chart/kuberay-apiserver/tests/ingress_test.yaml
@@ -30,34 +30,6 @@ tests:
           name: kuberay-apiserver
           namespace: kuberay-system
 
-  - it: Should create Ingress if `ingress.enabled` is `true`
-    capabilities:
-      majorVersion: 1
-      minorVersion: 14
-    set:
-      ingress:
-        enabled: true
-    asserts:
-      - containsDocument:
-          apiVersion: networking.k8s.io/v1beta1
-          kind: Ingress
-          name: kuberay-apiserver
-          namespace: kuberay-system
-
-  - it: Should create Ingress if `ingress.enabled` is `true`
-    capabilities:
-      majorVersion: 1
-      minorVersion: 12
-    set:
-      ingress:
-        enabled: true
-    asserts:
-      - containsDocument:
-          apiVersion: extensions/v1beta1
-          kind: Ingress
-          name: kuberay-apiserver
-          namespace: kuberay-system
-
   - it: Should have ingress backend service name matching the service name
     capabilities:
       majorVersion: 1

--- a/helm-chart/kuberay-apiserver/values.yaml
+++ b/helm-chart/kuberay-apiserver/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Image repository.
   repository: quay.io/kuberay/apiserver
   # -- Image tag.
-  tag: v1.6.0-rc.0
+  tag: v1.6.0
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 

--- a/helm-chart/kuberay-operator/Chart.yaml
+++ b/helm-chart/kuberay-operator/Chart.yaml
@@ -4,7 +4,7 @@ name: kuberay-operator
 
 description: A Helm chart for deploying the Kuberay operator on Kubernetes.
 
-version: 1.6.0-rc.0
+version: 1.6.0
 
 type: application
 

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -102,7 +102,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -122,7 +122,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/README.md
+++ b/helm-chart/kuberay-operator/README.md
@@ -1,6 +1,6 @@
 # kuberay-operator
 
-![Version: 1.6.0-rc.0](https://img.shields.io/badge/Version-1.6.0--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the Kuberay operator on Kubernetes.
 
@@ -29,8 +29,8 @@ helm version
   ```sh
   helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-  # Install both CRDs and KubeRay operator v1.6.0-rc.0.
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0
+  # Install both CRDs and KubeRay operator v1.6.0.
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
 
   # Check the KubeRay operator Pod in `default` namespace
   kubectl get pods
@@ -58,10 +58,10 @@ helm version
 
   ```sh
   # Step 1: Install CRDs only (for cluster admin)
-  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.6.0-rc.0&timeout=90s"
+  kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.6.0&timeout=90s"
 
   # Step 2: Install KubeRay operator only. (for developer)
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0 --skip-crds
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 --skip-crds
   ```
 
 ## List the chart
@@ -71,7 +71,7 @@ To list the `my-release` deployment:
 ```sh
 helm ls
 # NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
-# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.6.0-rc.0
+# kuberay-operator        default         1               2023-09-22 02:57:17.306616331 +0000 UTC deployed        kuberay-operator-1.6.0
 ```
 
 ## Uninstall the Chart
@@ -102,7 +102,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0-rc.0
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -122,7 +122,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0-rc.0
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true
@@ -149,7 +149,7 @@ spec:
 | componentOverride | string | `"kuberay-operator"` | String to override component name. |
 | replicas | int | `1` | Number of replicas for the KubeRay operator Deployment. |
 | image.repository | string | `"quay.io/kuberay/operator"` | Image repository. |
-| image.tag | string | `"v1.6.0-rc.0"` | Image tag. |
+| image.tag | string | `"v1.6.0"` | Image tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | imagePullSecrets | list | `[]` | Secrets with credentials to pull images from a private registry |
 | nodeSelector | object | `{}` | Restrict to run on particular nodes. |

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -104,7 +104,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0-rc.0
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -124,7 +124,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0-rc.0
+    targetRevision: v1.0.0-rc.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/README.md.gotmpl
+++ b/helm-chart/kuberay-operator/README.md.gotmpl
@@ -104,7 +104,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0
     path: helm-chart/kuberay-operator/crds
   destination:
     server: https://kubernetes.default.svc
@@ -124,7 +124,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.0.0-rc.0
+    targetRevision: v1.6.0
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true

--- a/helm-chart/kuberay-operator/values.yaml
+++ b/helm-chart/kuberay-operator/values.yaml
@@ -19,7 +19,7 @@ image:
   repository: quay.io/kuberay/operator
 
   # -- Image tag.
-  tag: v1.6.0-rc.0
+  tag: v1.6.0
 
   # -- Image pull policy.
   pullPolicy: IfNotPresent

--- a/helm-chart/ray-cluster/Chart.yaml
+++ b/helm-chart/ray-cluster/Chart.yaml
@@ -1,10 +1,12 @@
-apiVersion: v1
+apiVersion: v2
 
 name: ray-cluster
 
+type: application
+
 description: A Helm chart for deploying the RayCluster with the kuberay operator.
 
-version: 1.6.0-rc.0
+version: 1.6.0
 
 home: https://github.com/ray-project/kuberay
 

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -1,6 +1,6 @@
 # RayCluster
 
-![Version: 1.6.0-rc.0](https://img.shields.io/badge/Version-1.6.0--rc.0-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying the RayCluster with the kuberay operator.
 
@@ -30,15 +30,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.6.0-rc.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0
+# Step 3: Install both CRDs and KubeRay operator v1.1.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0
+helm install raycluster kuberay/ray-cluster --version 1.1.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods
@@ -88,9 +88,9 @@ helm uninstall raycluster
 | head.containerEnv | list | `[]` |  |
 | head.envFrom | list | `[]` | envFrom to pass to head pod |
 | head.resources.limits.cpu | string | `"1"` |  |
-| head.resources.limits.memory | string | `"2G"` |  |
+| head.resources.limits.memory | string | `"5Gi"` |  |
 | head.resources.requests.cpu | string | `"1"` |  |
-| head.resources.requests.memory | string | `"2G"` |  |
+| head.resources.requests.memory | string | `"5Gi"` |  |
 | head.resourceClaims | list | `[]` | ResourceClaims to allocate with the head pod |
 | head.annotations | object | `{}` | Extra annotations for head pod |
 | head.nodeSelector | object | `{}` | Node labels for head pod assignment |
@@ -111,7 +111,7 @@ helm uninstall raycluster
 | worker.groupName | string | `"workergroup"` | The name of the workergroup |
 | worker.replicas | int | `1` | The number of replicas for the worker pod |
 | worker.minReplicas | int | `1` | The minimum number of replicas for the worker pod |
-| worker.maxReplicas | int | `3` | The maximum number of replicas for the worker pod |
+| worker.maxReplicas | int | `5` | The maximum number of replicas for the worker pod |
 | worker.labels | object | `{}` | Labels for the worker pod |
 | worker.serviceAccountName | string | `""` |  |
 | worker.restartPolicy | string | `""` |  |
@@ -120,9 +120,9 @@ helm uninstall raycluster
 | worker.containerEnv | list | `[]` |  |
 | worker.envFrom | list | `[]` | envFrom to pass to worker pod |
 | worker.resources.limits.cpu | string | `"1"` |  |
-| worker.resources.limits.memory | string | `"1G"` |  |
+| worker.resources.limits.memory | string | `"1Gi"` |  |
 | worker.resources.requests.cpu | string | `"1"` |  |
-| worker.resources.requests.memory | string | `"1G"` |  |
+| worker.resources.requests.memory | string | `"1Gi"` |  |
 | worker.resourceClaims | list | `[]` | ResourceClaims to allocate with the worker pod |
 | worker.annotations | object | `{}` | Extra annotations for worker pod |
 | worker.nodeSelector | object | `{}` | Node labels for worker pod assignment |
@@ -142,7 +142,7 @@ helm uninstall raycluster
 | additionalWorkerGroups.smallGroup.disabled | bool | `true` |  |
 | additionalWorkerGroups.smallGroup.replicas | int | `0` | The number of replicas for the additional worker pod |
 | additionalWorkerGroups.smallGroup.minReplicas | int | `0` | The minimum number of replicas for the additional worker pod |
-| additionalWorkerGroups.smallGroup.maxReplicas | int | `3` | The maximum number of replicas for the additional worker pod |
+| additionalWorkerGroups.smallGroup.maxReplicas | int | `5` | The maximum number of replicas for the additional worker pod |
 | additionalWorkerGroups.smallGroup.labels | object | `{}` | Labels for the additional worker pod |
 | additionalWorkerGroups.smallGroup.serviceAccountName | string | `""` |  |
 | additionalWorkerGroups.smallGroup.restartPolicy | string | `""` |  |
@@ -150,9 +150,9 @@ helm uninstall raycluster
 | additionalWorkerGroups.smallGroup.containerEnv | list | `[]` |  |
 | additionalWorkerGroups.smallGroup.envFrom | list | `[]` | envFrom to pass to additional worker pod |
 | additionalWorkerGroups.smallGroup.resources.limits.cpu | int | `1` |  |
-| additionalWorkerGroups.smallGroup.resources.limits.memory | string | `"1G"` |  |
+| additionalWorkerGroups.smallGroup.resources.limits.memory | string | `"1Gi"` |  |
 | additionalWorkerGroups.smallGroup.resources.requests.cpu | int | `1` |  |
-| additionalWorkerGroups.smallGroup.resources.requests.memory | string | `"1G"` |  |
+| additionalWorkerGroups.smallGroup.resources.requests.memory | string | `"1Gi"` |  |
 | additionalWorkerGroups.smallGroup.resourceClaims | list | `[]` | ResourceClaims to allocate with the additional worker pod |
 | additionalWorkerGroups.smallGroup.annotations | object | `{}` | Extra annotations for additional worker pod |
 | additionalWorkerGroups.smallGroup.nodeSelector | object | `{}` | Node labels for additional worker pod assignment |

--- a/helm-chart/ray-cluster/README.md
+++ b/helm-chart/ray-cluster/README.md
@@ -30,15 +30,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.1.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+# Step 3: Install both CRDs and KubeRay operator v1.6.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.1.0
+helm install raycluster kuberay/ray-cluster --version 1.6.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.6.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods

--- a/helm-chart/ray-cluster/README.md.gotmpl
+++ b/helm-chart/ray-cluster/README.md.gotmpl
@@ -32,15 +32,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.6.0-rc.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0-rc.0
+# Step 3: Install both CRDs and KubeRay operator v1.1.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0
+helm install raycluster kuberay/ray-cluster --version 1.1.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.6.0-rc.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods

--- a/helm-chart/ray-cluster/README.md.gotmpl
+++ b/helm-chart/ray-cluster/README.md.gotmpl
@@ -32,15 +32,15 @@ kind create cluster
 # Step 2: Register a Helm chart repo
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Step 3: Install both CRDs and KubeRay operator v1.1.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.1.0
+# Step 3: Install both CRDs and KubeRay operator v1.6.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
 
 # Step 4: Install a RayCluster custom resource
 # (For x86_64 users)
-helm install raycluster kuberay/ray-cluster --version 1.1.0
+helm install raycluster kuberay/ray-cluster --version 1.6.0
 # (For arm64 users, e.g. Mac M1)
 # See here for all available arm64 images: https://hub.docker.com/r/rayproject/ray/tags?page=1&name=aarch64
-helm install raycluster kuberay/ray-cluster --version 1.1.0 --set image.tag=nightly-aarch64
+helm install raycluster kuberay/ray-cluster --version 1.6.0 --set image.tag=nightly-aarch64
 
 # Step 5: Verify the installation of KubeRay operator and RayCluster
 kubectl get pods

--- a/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
+++ b/helm-chart/ray-cluster/templates/raycluster-cluster.yaml
@@ -381,10 +381,10 @@ spec:
           resources:
             limits:
               cpu: "1"
-              memory: "1G"
+              memory: "1Gi"
             requests:
               cpu: "1"
-              memory: "1G"
+              memory: "1Gi"
           {{- end }}
           {{- with $values.securityContext }}
           securityContext:

--- a/helm-chart/ray-cluster/tests/raycluster_test.yaml
+++ b/helm-chart/ray-cluster/tests/raycluster_test.yaml
@@ -1854,10 +1854,10 @@ tests:
           value:
             limits:
               cpu: "1"
-              memory: 1G
+              memory: 1Gi
             requests:
               cpu: "1"
-              memory: 1G
+              memory: 1Gi
 
   - it: Should add lifecycle if `additionalWorkerGroups.smallGroup.lifecycle` is set
     set:

--- a/helm-chart/ray-cluster/values.yaml
+++ b/helm-chart/ray-cluster/values.yaml
@@ -128,10 +128,10 @@ head:
     limits:
       cpu: "1"
       # To avoid out-of-memory issues, never allocate less than 2G memory for the Ray head.
-      memory: "2G"
+      memory: "5Gi"
     requests:
       cpu: "1"
-      memory: "2G"
+      memory: "5Gi"
 
   # -- ResourceClaims to allocate with the head pod
   resourceClaims: []
@@ -210,7 +210,7 @@ worker:
   minReplicas: 1
 
   # -- The maximum number of replicas for the worker pod
-  maxReplicas: 3
+  maxReplicas: 5
 
   # -- Labels for the worker pod
   labels: {}
@@ -249,10 +249,10 @@ worker:
   resources:
     limits:
       cpu: "1"
-      memory: "1G"
+      memory: "1Gi"
     requests:
       cpu: "1"
-      memory: "1G"
+      memory: "1Gi"
 
   # -- ResourceClaims to allocate with the worker pod
   resourceClaims: []
@@ -324,7 +324,7 @@ additionalWorkerGroups:
     minReplicas: 0
 
     # -- The maximum number of replicas for the additional worker pod
-    maxReplicas: 3
+    maxReplicas: 5
 
     # -- Labels for the additional worker pod
     labels: {}
@@ -360,10 +360,10 @@ additionalWorkerGroups:
     resources:
       limits:
         cpu: 1
-        memory: "1G"
+        memory: "1Gi"
       requests:
         cpu: 1
-        memory: "1G"
+        memory: "1Gi"
 
     # -- ResourceClaims to allocate with the additional worker pod
     resourceClaims: []


### PR DESCRIPTION
## Summary
- Sync Helm charts from kuberay repo `release-1.6` branch for the v1.6.0 release
- Bump chart versions from `1.6.0-rc.0` to `1.6.0` for kuberay-operator, kuberay-apiserver, and ray-cluster
- Minor updates to README, values, and templates

